### PR TITLE
Introduced `@Reference` property wrapper.

### DIFF
--- a/FireSnapshot.xcodeproj/project.pbxproj
+++ b/FireSnapshot.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -38,6 +38,7 @@
 		1617CD632340CB1700099FC5 /* CodableErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1617CD562340CB1700099FC5 /* CodableErrors.swift */; };
 		1617CD662340CC9100099FC5 /* FirestoreDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1617CD642340CC9100099FC5 /* FirestoreDecoder.swift */; };
 		1617CD672340CC9100099FC5 /* FirestoreEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1617CD652340CC9100099FC5 /* FirestoreEncoder.swift */; };
+		1659EBEA234113D900BD510D /* Reference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1659EBE9234113D900BD510D /* Reference.swift */; };
 		C7AC0728461714610F570CB5 /* Pods_FireSnapshotTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA9C3F24DAB7C0106A5A122D /* Pods_FireSnapshotTests.framework */; };
 		CE86EA2FE75980E5237BCED1 /* Pods_FireSnapshot.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8925B294155F0A90A59C088 /* Pods_FireSnapshot.framework */; };
 /* End PBXBuildFile section */
@@ -87,6 +88,7 @@
 		1617CD562340CB1700099FC5 /* CodableErrors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodableErrors.swift; sourceTree = "<group>"; };
 		1617CD642340CC9100099FC5 /* FirestoreDecoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirestoreDecoder.swift; sourceTree = "<group>"; };
 		1617CD652340CC9100099FC5 /* FirestoreEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirestoreEncoder.swift; sourceTree = "<group>"; };
+		1659EBE9234113D900BD510D /* Reference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reference.swift; sourceTree = "<group>"; };
 		25B42645485A6D1C6682724A /* Pods-FireSnapshot.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FireSnapshot.debug.xcconfig"; path = "Target Support Files/Pods-FireSnapshot/Pods-FireSnapshot.debug.xcconfig"; sourceTree = "<group>"; };
 		648BB37871CC0A94356CF0DB /* Pods-FireSnapshot.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FireSnapshot.release.xcconfig"; path = "Target Support Files/Pods-FireSnapshot/Pods-FireSnapshot.release.xcconfig"; sourceTree = "<group>"; };
 		B90A83261856C6D7C28E7346 /* Pods-FireSnapshotTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FireSnapshotTests.debug.xcconfig"; path = "Target Support Files/Pods-FireSnapshotTests/Pods-FireSnapshotTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 				1617CD43233FB88200099FC5 /* Result+.swift */,
 				1617CD452340B23D00099FC5 /* FieldNameReferable.swift */,
 				1617CD472340B3F900099FC5 /* QueryBuilder.swift */,
+				1659EBE9234113D900BD510D /* Reference.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -404,6 +407,7 @@
 				1617CD602340CB1700099FC5 /* FieldValue+Encodable.swift in Sources */,
 				1617CD44233FB88200099FC5 /* Result+.swift in Sources */,
 				1617CD3E233FA5B300099FC5 /* IncrementableDouble.swift in Sources */,
+				1659EBEA234113D900BD510D /* Reference.swift in Sources */,
 				1617CD572340CB1700099FC5 /* WriteBatch+WriteEncodable.swift in Sources */,
 				1617CD672340CC9100099FC5 /* FirestoreEncoder.swift in Sources */,
 				1617CD612340CB1700099FC5 /* GeoPoint+Codable.swift in Sources */,

--- a/FireSnapshot/Sources/Reference.swift
+++ b/FireSnapshot/Sources/Reference.swift
@@ -1,0 +1,36 @@
+//
+// Copyright © Suguru Kishimoto. All rights reserved.
+//
+
+import Foundation
+import FirebaseFirestore
+
+@propertyWrapper
+public struct Reference<D>: Codable  where D: Codable {
+    public private(set) var wrappedValue: DocumentReference
+    public init(wrappedValue: DocumentReference) {
+        self.wrappedValue = wrappedValue
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        wrappedValue = try container.decode(DocumentReference.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(wrappedValue)
+    }
+
+    public var projectedValue: Self {
+        self
+    }
+
+    func get(source: FirestoreSource = .default, completion: @escaping Snapshot<D>.DocumentReadResultBlock) {
+        Snapshot<D>.get(wrappedValue, source: source, completion: completion)
+    }
+
+    func listen(includeMetadataChanges: Bool = false, completion: @escaping Snapshot<D>.DocumentReadResultBlock) {
+        Snapshot<D>.listen(wrappedValue, includeMetadataChanges: includeMetadataChanges, completion: completion)
+    }
+}


### PR DESCRIPTION
I just implemented `@Reference` property wrapper.

- Usage

```swift
struct User: Codable {
    var name: String
}

struct Task: Codable {
    var title: String
    // Define DocumentReference type property with `@Reference` and specify model type.
    @Reference<User> var user: DocumentReference
}

Snapshot<Task>.get(Path.task(taskID: taskID)) { result in
    guard case let .success(task) = result else {
        return 
    }
    // Use `DocumentReference`
    print(task.user)
    
    // Get model as given model type from `DocumentReference` if set '$' prefix.
    task.$user.get { result in
        print((try? result.get())?.data.name)
    }

    // Also can listen
    let listener = task.$user.listen { result in
        print((try? result.get())?.data.name)
    }
}
```