### PR TITLE
Renew `Path`

### DIFF
--- a/FireSnapshot/Sources/Path.swift
+++ b/FireSnapshot/Sources/Path.swift
@@ -5,24 +5,43 @@
 import FirebaseFirestore
 import Foundation
 
+public class DocumentPaths {
+    fileprivate init() {
+    }
+}
+
+public class CollectionPaths {
+    fileprivate init() {
+    }
+}
+
+
 public protocol FirestorePath: Equatable {
     var path: String { get }
     init(_ path: String)
     func verify() -> Bool
 }
 
-public struct DocumentPath: FirestorePath {
+public class DocumentPath<T>: DocumentPaths, FirestorePath where T: Codable {
     public let path: String
 
-    init(_ collectionPath: CollectionPath, _ documentID: String) {
-        self.init([collectionPath.path, documentID].joined(separator: "/"))
+    fileprivate convenience init(_ collectionPath: String, _ documentID: String) {
+        self.init([collectionPath, documentID].joined(separator: "/"))
     }
 
-    public init(_ path: String) {
+    fileprivate convenience init<U>(_ collectionPath: CollectionPath<U>, _ documentID: String) where U: Codable {
+        self.init(collectionPath.path, documentID)
+    }
+
+    required public init(_ path: String) {
         self.path = path
     }
 
-    public func collection(_ collectionName: String) -> CollectionPath {
+    public func collection(_ collectionName: String) -> CollectionPath<T> {
+        CollectionPath(self, collectionName)
+    }
+
+    public func collection<U>(_ collectionName: String) -> CollectionPath<U> where U: Codable{
         CollectionPath(self, collectionName)
     }
 
@@ -35,20 +54,32 @@ public struct DocumentPath: FirestorePath {
     public var documentReference: DocumentReference {
         Firestore.firestore().document(path)
     }
+
+    public static func == (lhs: DocumentPath<T>, rhs: DocumentPath<T>) -> Bool {
+        lhs.path == rhs.path
+    }
 }
 
-public struct CollectionPath: FirestorePath {
+public class CollectionPath<T>: CollectionPaths, FirestorePath where T: Codable {
     public let path: String
 
-    public init(_ documentPath: DocumentPath, _ collectionName: String) {
-        self.init([documentPath.path, collectionName].joined(separator: "/"))
+    fileprivate convenience init(_ documentPath: String, _ collectionName: String) {
+        self.init([documentPath, collectionName].joined(separator: "/"))
     }
 
-    public init(_ path: String) {
+    fileprivate convenience init<U>(_ documentPath: DocumentPath<U>, _ collectionName: String) where U: Codable {
+        self.init(documentPath.path, collectionName)
+    }
+
+    required public init(_ path: String) {
         self.path = path
     }
 
-    public func doc(_ documentID: String) -> DocumentPath {
+    public func document(_ documentID: String) -> DocumentPath<T> {
+        DocumentPath(self, documentID)
+    }
+
+    public func document<U>(_ documentID: String) -> DocumentPath<U> where U: Codable {
         DocumentPath(self, documentID)
     }
 
@@ -68,5 +99,85 @@ public struct CollectionPath: FirestorePath {
         } else {
             return Firestore.firestore().collection(path).document()
         }
+    }
+
+    public static func == (lhs: CollectionPath<T>, rhs: CollectionPath<T>) -> Bool {
+        lhs.path == rhs.path
+    }
+}
+
+public class AnyDocumentPath: DocumentPaths, FirestorePath {
+    public let path: String
+
+    fileprivate convenience init(_ collectionPath: String, _ documentID: String) {
+        self.init([collectionPath, documentID].joined(separator: "/"))
+    }
+
+    fileprivate convenience init<T>(_ collectionPath: CollectionPath<T>, _ documentID: String) where T: Codable {
+        self.init(collectionPath.path, documentID)
+    }
+
+    public required init(_ path: String) {
+        self.path = path
+    }
+
+    public convenience init<T>(_ path: DocumentPath<T>) {
+        self.init(path.path)
+    }
+
+    public func anyCollection(_ collectionName: String) -> AnyCollectionPath {
+        AnyCollectionPath(self.path, collectionName)
+    }
+
+    public func collection<T>(_ collectionName: String) -> CollectionPath<T> where T: Codable {
+        CollectionPath(self.path, collectionName)
+    }
+
+    public func verify() -> Bool {
+        let components = path.components(separatedBy: "/")
+        let isValid = components.count % 2 == 0 && !components.last!.isEmpty
+        return isValid
+    }
+
+    public static func == (lhs: AnyDocumentPath, rhs: AnyDocumentPath) -> Bool {
+        lhs.path == rhs.path
+    }
+}
+
+public class AnyCollectionPath: CollectionPaths, FirestorePath {
+    public let path: String
+
+    fileprivate convenience init(_ documentPath: String, _ collectionName: String) {
+        self.init([documentPath, collectionName].joined(separator: "/"))
+    }
+
+    fileprivate convenience init<T>(_ documentPath: DocumentPath<T>, _ collectionName: String) where T: Codable {
+        self.init(documentPath.path, collectionName)
+    }
+
+    public required init(_ path: String) {
+        self.path = path
+    }
+
+    public convenience init<T>(_ path: CollectionPath<T>) {
+        self.init(path.path)
+    }
+
+    public func anyDocument(_ documentID: String) -> AnyDocumentPath {
+        AnyDocumentPath(self.path, documentID)
+    }
+
+    public func document<T>(_ documentID: String) -> DocumentPath<T> where T: Codable {
+        DocumentPath(self.path, documentID)
+    }
+
+    public func verify() -> Bool {
+        let components = path.components(separatedBy: "/")
+        let isValid = components.count % 2 == 1 && !components.last!.isEmpty
+        return isValid
+    }
+
+    public static func == (lhs: AnyCollectionPath, rhs: AnyCollectionPath) -> Bool {
+        lhs.path == rhs.path
     }
 }

--- a/FireSnapshot/Sources/Snapshot+Read.swift
+++ b/FireSnapshot/Sources/Snapshot+Read.swift
@@ -10,7 +10,7 @@ public extension Snapshot {
     typealias DocumentReadResultBlock<T: Codable> = (Result<Snapshot<T>, Error>) -> Void
     typealias CollectionReadResultBlock<T: Codable> = (Result<[Snapshot<T>], Error>) -> Void
 
-    static func get(_ path: DocumentPath,
+    static func get(_ path: DocumentPath<Data>,
                     source: FirestoreSource = .default,
                     completion: @escaping DocumentReadResultBlock<Data>) {
         get(path.documentReference, source: source, completion: completion)
@@ -22,7 +22,7 @@ public extension Snapshot {
         reference.getDocument(source: source, completion: documentReadCompletion(completion))
     }
 
-    static func get(_ path: CollectionPath,
+    static func get(_ path: CollectionPath<Data>,
                     queryBuilder: QueryBuilder = { $0 },
                     source: FirestoreSource = .default,
                     completion: @escaping CollectionReadResultBlock<Data>) {
@@ -39,17 +39,17 @@ public extension Snapshot {
         )
     }
 
-    static func get<T>(_ collectionGroup: CollectionGroup<T>,
-                       queryBuilder: QueryBuilder = { $0 },
-                       source: FirestoreSource = .default,
-                       completion: @escaping CollectionReadResultBlock<T>) where T: Codable {
+    static func get(_ collectionGroup: CollectionGroup<Data>,
+                    queryBuilder: QueryBuilder = { $0 },
+                    source: FirestoreSource = .default,
+                    completion: @escaping CollectionReadResultBlock<Data>) {
         queryBuilder(collectionGroup.query).getDocuments(
             source: source,
             completion: collectionReadCompletion(completion)
         )
     }
 
-    static func listen(_ path: DocumentPath,
+    static func listen(_ path: DocumentPath<Data>,
                        includeMetadataChanges: Bool = false,
                        completion: @escaping DocumentReadResultBlock<Data>) {
         listen(path.documentReference, includeMetadataChanges: includeMetadataChanges, completion: completion)
@@ -64,10 +64,10 @@ public extension Snapshot {
         )
     }
 
-    static func listen(_ path: CollectionPath,
-                     queryBuilder: QueryBuilder = { $0 },
-                     includeMetadataChanges: Bool = false,
-                     completion: @escaping CollectionReadResultBlock<Data>) -> ListenerRegistration {
+    static func listen(_ path: CollectionPath<Data>,
+                       queryBuilder: QueryBuilder = { $0 },
+                       includeMetadataChanges: Bool = false,
+                       completion: @escaping CollectionReadResultBlock<Data>) -> ListenerRegistration {
         listen(
             path.collectionReference,
             queryBuilder: queryBuilder,
@@ -77,16 +77,16 @@ public extension Snapshot {
     }
 
     static func listen(_ reference: CollectionReference,
-                     queryBuilder: QueryBuilder = { $0 },
-                     includeMetadataChanges: Bool = false,
-                     completion: @escaping CollectionReadResultBlock<Data>) -> ListenerRegistration {
+                       queryBuilder: QueryBuilder = { $0 },
+                       includeMetadataChanges: Bool = false,
+                       completion: @escaping CollectionReadResultBlock<Data>) -> ListenerRegistration {
         queryBuilder(reference).addSnapshotListener(
             includeMetadataChanges: includeMetadataChanges,
             listener: collectionReadCompletion(completion)
         )
     }
 
-    static func listen<T>(_ collectionGroup: CollectionGroup<T>,
+    static func listen(_ collectionGroup: CollectionGroup<Data>,
                        queryBuilder: QueryBuilder = { $0 },
                        includeMetadataChanges: Bool = false,
                        completion: @escaping CollectionReadResultBlock<Data>) -> ListenerRegistration {

--- a/FireSnapshot/Sources/Snapshot.swift
+++ b/FireSnapshot/Sources/Snapshot.swift
@@ -14,7 +14,7 @@ public final class Snapshot<D>: SnapshotType where D: Codable {
     public typealias DataFactory = (DocumentReference) -> D
     public var data: D
     public let reference: DocumentReference
-    public var path: DocumentPath {
+    public var path: DocumentPath<D> {
         DocumentPath(reference.path)
     }
 
@@ -26,20 +26,20 @@ public final class Snapshot<D>: SnapshotType where D: Codable {
         self.data = data
     }
 
-    public convenience init(data: D, path: DocumentPath) {
+    public convenience init(data: D, path: DocumentPath<D>) {
         self.init(data: data, reference: path.documentReference)
     }
 
-    public convenience init(dataFactory: DataFactory, path: DocumentPath) {
+    public convenience init(dataFactory: DataFactory, path: DocumentPath<D>) {
         let ref = path.documentReference
         self.init(data: dataFactory(ref), reference: ref)
     }
 
-    public convenience init(data: D, path: CollectionPath, id: String? = nil) {
+    public convenience init(data: D, path: CollectionPath<D>, id: String? = nil) {
         self.init(data: data, reference: path.documentRefernce(id: id))
     }
 
-    public convenience init(dataFactory: DataFactory, path: CollectionPath, id: String? = nil) {
+    public convenience init(dataFactory: DataFactory, path: CollectionPath<D>, id: String? = nil) {
         let ref = path.documentRefernce(id: id)
         self.init(data: dataFactory(ref), reference: ref)
     }

--- a/FireSnapshot/Sources/Transaction+Snapshot.swift
+++ b/FireSnapshot/Sources/Transaction+Snapshot.swift
@@ -6,7 +6,7 @@ import Foundation
 import FirebaseFirestore
 
 extension Transaction {
-    func get<D>(_ path: DocumentPath) throws -> Snapshot<D> {
+    func get<D>(_ path: DocumentPath<D>) throws -> Snapshot<D> {
         try .init(snapshot: try getDocument(path.documentReference))
     }
 


### PR DESCRIPTION
- Define `DocumentPaths`, `CollectionPaths`
- Modify `DocumentPath` to `DocumentPath<T>`
- Modify `CollectionPath` to `CollectionPath<T>`
- Define `AnyDocumentPath`, `AnyCollectionPath`
- Improved `Snapshot.get|listen` with the new typed-path.

### Usage

```swift
struct Task: Codable {
    // ...
}

extension CollectionPaths {
    static let tasks = CollectionPath<Task>("tasks")
}

extension DocumentPaths {
    static func task(taskID: String) -> DocumentPath<Task> {
        CollectionPaths.tasks.document(taskID)
    }
}

// get a task
Snapshot.get(.task(taskID: "xxxx")) { result in
    // ...
}

// get tasks
Snapshot.get(.tasks) { result in
    // ...
}

// create snapshot

let task1 = Snapshot(data: .init(), path: .tasks)
let task2 = Snapshot(data: .init(), path: .task(taskID: "yyyy"))

```