### PR TITLE
use dynamicMemberLookup for avoiding to rewrite snapshot.data.

### DIFF
--- a/FireSnapshot/Sources/Snapshot.swift
+++ b/FireSnapshot/Sources/Snapshot.swift
@@ -9,10 +9,11 @@ public protocol SnapshotType {
     associatedtype Data: Codable
 }
 
+@dynamicMemberLookup
 public final class Snapshot<D>: SnapshotType where D: Codable {
     public typealias Data = D
     public typealias DataFactory = (DocumentReference) -> D
-    public var data: D
+    public private(set) var data: D
     public let reference: DocumentReference
     public var path: DocumentPath<D> {
         DocumentPath(reference.path)
@@ -71,6 +72,15 @@ public final class Snapshot<D>: SnapshotType where D: Codable {
             fields[SnapshotTimestampKey.updateTime.rawValue] = FieldValue.serverTimestamp()
         }
         return fields
+    }
+
+    public subscript<V>(dynamicMember keyPath: WritableKeyPath<D, V>) -> V {
+        get {
+            return data[keyPath: keyPath]
+        }
+        set {
+            data[keyPath: keyPath] = newValue
+        }
     }
 }
 

--- a/FireSnapshotTests/AtomicArrayTests.swift
+++ b/FireSnapshotTests/AtomicArrayTests.swift
@@ -36,14 +36,14 @@ class AtomicArrayTests: XCTestCase {
                 Snapshot.get(mock.path) { result in
                     switch result {
                     case let .success(m):
-                        XCTAssertEqual(m.data.languages, ["ja"])
-                        m.data.$languages.union("en")
-                        XCTAssertEqual(m.data.languages, ["ja", "en"])
+                        XCTAssertEqual(m.languages, ["ja"])
+                        m.$languages.union("en")
+                        XCTAssertEqual(m.languages, ["ja", "en"])
                         m.update { result in
                             switch result {
                             case .success:
                                 Snapshot.get(mock.path) { result in
-                                    XCTAssertEqual((try? result.get())?.data.languages, ["ja", "en"])
+                                    XCTAssertEqual((try? result.get())?.languages, ["ja", "en"])
                                     exp.fulfill()
                                 }
                             case let .failure(error):
@@ -58,7 +58,7 @@ class AtomicArrayTests: XCTestCase {
                 XCTFail("\(error)")
             }
         }
-        wait(for: [exp], timeout: 10.0)
+        wait(for: [exp], timeout: 30.0)
     }
 
     func testRemoveUpdate() {
@@ -70,14 +70,14 @@ class AtomicArrayTests: XCTestCase {
                 Snapshot.get(mock.path) { result in
                     switch result {
                     case let .success(m):
-                        XCTAssertEqual(m.data.languages, ["ja", "en", "zh"])
-                        m.data.$languages.remove("en")
-                        XCTAssertEqual(m.data.languages, ["ja", "zh"])
+                        XCTAssertEqual(m.languages, ["ja", "en", "zh"])
+                        m.$languages.remove("en")
+                        XCTAssertEqual(m.languages, ["ja", "zh"])
                         m.update { result in
                             switch result {
                             case .success:
                                 Snapshot.get(mock.path) { result in
-                                    XCTAssertEqual((try? result.get())?.data.languages, ["ja", "zh"])
+                                    XCTAssertEqual((try? result.get())?.languages, ["ja", "zh"])
                                     exp.fulfill()
                                 }
                             case let .failure(error):
@@ -92,7 +92,7 @@ class AtomicArrayTests: XCTestCase {
                 XCTFail("\(error)")
             }
         }
-        wait(for: [exp], timeout: 10.0)
+        wait(for: [exp], timeout: 30.0)
     }
 
     func testAtomicArrayBehavior() {

--- a/FireSnapshotTests/FireSnapshotTests.swift
+++ b/FireSnapshotTests/FireSnapshotTests.swift
@@ -71,20 +71,6 @@ class FireSnapshotTests: XCTestCase {
                         XCTAssertEqual((try? result.get())?.count, 1)
                         exp.fulfill()
                     }
-//                    Snapshot<User>.get(snapshot.path) { result in
-//                        switch result {
-//                        case let .success(user):
-//                            XCTAssertEqual(user.data.id.id, snapshot.reference.documentID)
-//                            XCTAssertEqual(user.data.taskRef.path, taskSnapshot.reference.path)
-//                            user.data.$taskRef.get { result in
-//                                XCTAssertEqual((try? result.get())?.data.name, "test")
-//                                exp.fulfill()
-//                            }
-//                        case let .failure(error):
-//                            XCTFail("\(error)")
-//                            exp.fulfill()
-//                        }
-//                    }
                 }
             }
         }
@@ -101,7 +87,7 @@ class FireSnapshotTests: XCTestCase {
         task2.create { result in
             switch result {
             case .success:
-                task2.data.name = "mike"
+                task2.name = "mike"
                 let batch = Firestore.firestore().batch()
                 try! batch.create(task)
                 try! batch.create(user)
@@ -150,11 +136,11 @@ class FireSnapshotTests: XCTestCase {
         taskSnapshot.create { result in
             switch result {
             case .success:
-                taskSnapshot.data.$userNames.union(["John", "Lisa"])
+                taskSnapshot.$userNames.union(["John", "Lisa"])
                 taskSnapshot.update { _ in
                     Snapshot.get(.task(taskID: taskSnapshot.reference.documentID)) { result in
-                        XCTAssertEqual((try? result.get())?.data.userNames.count, 3)
-                        XCTAssertEqual((try? result.get())?.data.userNames, ["Mike", "John", "Lisa"])
+                        XCTAssertEqual((try? result.get())?.userNames.count, 3)
+                        XCTAssertEqual((try? result.get())?.userNames, ["Mike", "John", "Lisa"])
                         exp.fulfill()
                     }
                 }
@@ -173,12 +159,12 @@ class FireSnapshotTests: XCTestCase {
         taskSnapshot.create { result in
             switch result {
             case .success:
-                taskSnapshot.data.bio?.delete()
+                taskSnapshot.bio?.delete()
                 taskSnapshot.update { _ in
                     Snapshot.get(taskSnapshot.path) { result in
                         switch result {
                         case let .success(task):
-                            XCTAssertEqual(task.data.bio?.value, nil)
+                            XCTAssertEqual(task.bio?.value, nil)
                         case let .failure(error):
                             XCTFail("\(error)")
                         }

--- a/FireSnapshotTests/IncrementableNumberTests.swift
+++ b/FireSnapshotTests/IncrementableNumberTests.swift
@@ -45,15 +45,15 @@ class IncrementableNumberTests: XCTestCase {
             Snapshot.get(mock1.path) { result in
                 switch result {
                 case let .success(mock):
-                    XCTAssertEqual(mock.data.count, 5)
-                    mock.data.$count.increment(10)
-                    XCTAssertEqual(mock.data.count, 15)
-                    XCTAssertEqual(mock.data.$count.incrementValue, 10)
+                    XCTAssertEqual(mock.count, 5)
+                    mock.$count.increment(10)
+                    XCTAssertEqual(mock.count, 15)
+                    XCTAssertEqual(mock.$count.incrementValue, 10)
                     mock.update { result in
                         switch result {
                         case .success:
                             Snapshot.get(mock1.path) { result in
-                                XCTAssertEqual((try? result.get())?.data.count, 15)
+                                XCTAssertEqual((try? result.get())?.count, 15)
                                 exp.fulfill()
                             }
                         case let .failure(error):
@@ -68,15 +68,15 @@ class IncrementableNumberTests: XCTestCase {
             Snapshot.get(mock2.path) { result in
                 switch result {
                 case let .success(mock):
-                    XCTAssertEqual(mock.data.distance, 5.0)
-                    mock.data.$distance.increment(10.0)
-                    XCTAssertEqual(mock.data.distance, 15.0)
-                    XCTAssertEqual(mock.data.$distance.incrementValue, 10.0)
+                    XCTAssertEqual(mock.distance, 5.0)
+                    mock.$distance.increment(10.0)
+                    XCTAssertEqual(mock.distance, 15.0)
+                    XCTAssertEqual(mock.$distance.incrementValue, 10.0)
                     mock.update { result in
                         switch result {
                         case .success:
                             Snapshot.get(mock2.path) { result in
-                                XCTAssertEqual((try? result.get())?.data.distance, 15.0)
+                                XCTAssertEqual((try? result.get())?.distance, 15.0)
                                 exp.fulfill()
                             }
                         case let .failure(error):


### PR DESCRIPTION
`Snapshot` has conformed to `dynamicMemberLookup`.
it can access `Data`'s property using KeyPath.
Instead, assignment to `snapshot.data` and `snapshot.data.property` is no longer possible. (read-only)

```swift
struct Task {
    var name: String = "title"
}

let snapshot = Snapshot<Task>(data: .init(), path: .tasks)

// OK.
print(snapshot.title)
snapshot.title = "task title"

// NG
snapshot.data = .init()
snapshot.data.title = "task title"
```