### PR TITLE
Replicate

### DIFF
--- a/FireSnapshot.xcodeproj/project.pbxproj
+++ b/FireSnapshot.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		1659EBF223431E8800BD510D /* Transaction+Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1659EBF123431E8800BD510D /* Transaction+Snapshot.swift */; };
 		1659EBF423433F9300BD510D /* AtomicArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1659EBF323433F9300BD510D /* AtomicArray.swift */; };
 		1659EBF6234446B900BD510D /* DeletableField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1659EBF5234446B900BD510D /* DeletableField.swift */; };
+		1694DF5F234D78E800B7807A /* ReplicatedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1694DF5E234D78E800B7807A /* ReplicatedTests.swift */; };
 		16B699E4234636DD005877A9 /* CollectionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B699E3234636DD005877A9 /* CollectionGroup.swift */; };
 		16B699E82348CA80005877A9 /* PathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B699E72348CA80005877A9 /* PathTests.swift */; };
 		C7AC0728461714610F570CB5 /* Pods_FireSnapshotTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA9C3F24DAB7C0106A5A122D /* Pods_FireSnapshotTests.framework */; };
@@ -103,6 +104,7 @@
 		1659EBF123431E8800BD510D /* Transaction+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Transaction+Snapshot.swift"; sourceTree = "<group>"; };
 		1659EBF323433F9300BD510D /* AtomicArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicArray.swift; sourceTree = "<group>"; };
 		1659EBF5234446B900BD510D /* DeletableField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletableField.swift; sourceTree = "<group>"; };
+		1694DF5E234D78E800B7807A /* ReplicatedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplicatedTests.swift; sourceTree = "<group>"; };
 		16B699E3234636DD005877A9 /* CollectionGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionGroup.swift; sourceTree = "<group>"; };
 		16B699E72348CA80005877A9 /* PathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathTests.swift; sourceTree = "<group>"; };
 		25B42645485A6D1C6682724A /* Pods-FireSnapshot.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FireSnapshot.debug.xcconfig"; path = "Target Support Files/Pods-FireSnapshot/Pods-FireSnapshot.debug.xcconfig"; sourceTree = "<group>"; };
@@ -199,6 +201,7 @@
 				16B699E72348CA80005877A9 /* PathTests.swift */,
 				1622A2E9234AAE630003826D /* IncrementableNumberTests.swift */,
 				1622A2EB234ABCE30003826D /* AtomicArrayTests.swift */,
+				1694DF5E234D78E800B7807A /* ReplicatedTests.swift */,
 			);
 			path = FireSnapshotTests;
 			sourceTree = "<group>";
@@ -462,6 +465,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1694DF5F234D78E800B7807A /* ReplicatedTests.swift in Sources */,
 				16B699E82348CA80005877A9 /* PathTests.swift in Sources */,
 				1622A2EC234ABCE30003826D /* AtomicArrayTests.swift in Sources */,
 				1617CD36233F4E4C00099FC5 /* FirebaseTestHelper.swift in Sources */,

--- a/FireSnapshot/Sources/Snapshot.swift
+++ b/FireSnapshot/Sources/Snapshot.swift
@@ -82,6 +82,18 @@ public final class Snapshot<D>: SnapshotType where D: Codable {
             data[keyPath: keyPath] = newValue
         }
     }
+
+    public func replicated() throws -> Snapshot<D> {
+        let replicated = Snapshot<D>(
+            data: try Firestore.Decoder().decode(D.self, from: try Firestore.Encoder().encode(data)),
+            path: path
+        )
+        if data is HasTimestamps {
+            replicated._createTime = _createTime
+            replicated._updateTime = _updateTime
+        }
+        return replicated
+    }
 }
 
 extension Snapshot: Equatable where D: Equatable {

--- a/FireSnapshot/Sources/Snapshot.swift
+++ b/FireSnapshot/Sources/Snapshot.swift
@@ -83,10 +83,10 @@ public final class Snapshot<D>: SnapshotType where D: Codable {
         }
     }
 
-    public func replicated() throws -> Snapshot<D> {
+    public func replicated(path: DocumentPath<D>? = nil) throws -> Snapshot<D> {
         let replicated = Snapshot<D>(
             data: try Firestore.Decoder().decode(D.self, from: try Firestore.Encoder().encode(data)),
-            path: path
+            path: path ?? self.path
         )
         if data is HasTimestamps {
             replicated._createTime = _createTime

--- a/FireSnapshotTests/ReplicatedTests.swift
+++ b/FireSnapshotTests/ReplicatedTests.swift
@@ -1,0 +1,80 @@
+//
+// Copyright © Suguru Kishimoto. All rights reserved.
+//
+
+import XCTest
+import FirebaseFirestore
+
+@testable import FireSnapshot
+
+private extension CollectionPaths {
+    static let mocks = CollectionPath<Mock>("mocks")
+}
+
+private struct Mock: Codable, HasTimestamps {
+    var name: String = "Mike"
+}
+
+class ReplicatedTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        FirebaseTestHelper.setupFirebaseApp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        FirebaseTestHelper.deleteFirebaseApp()
+    }
+
+    func testReplicated() {
+        let mock = Snapshot(data: .init(), path: .mocks)
+        let replicated = try? mock.replicated()
+        XCTAssertNotNil(replicated)
+        XCTAssertEqual(mock.path, replicated?.path)
+        XCTAssertEqual(mock.name, replicated?.name)
+        mock.name = "changed"
+        XCTAssertNotEqual(mock.name, replicated?.name)
+    }
+
+    func testHasTimestampReplicated() {
+        let exp = expectation(description: #function)
+        let mock = Snapshot(data: .init(), path: .mocks)
+        mock.create { result in
+            switch result {
+            case .success:
+                Snapshot.get(mock.path) { result in
+                    switch result {
+                    case let .success(m):
+                        XCTAssertNotNil(m.createTime)
+                        XCTAssertNotNil(m.updateTime)
+                        let replicated = try? m.replicated()
+                        XCTAssertNotNil(replicated)
+                        XCTAssertNotNil(replicated?.createTime)
+                        XCTAssertNotNil(replicated?.updateTime)
+                        XCTAssertEqual(m.createTime, replicated?.createTime)
+                        XCTAssertEqual(m.updateTime, replicated?.updateTime)
+                        XCTAssertEqual(m.path, replicated?.path)
+                        XCTAssertEqual(m.name, replicated?.name)
+                        exp.fulfill()
+
+                    case let .failure(error):
+                        XCTFail("\(error)")
+                    }
+                }
+            case let .failure(error):
+                XCTFail("\(error)")
+            }
+        }
+        wait(for: [exp], timeout: 10.0)
+    }
+
+    func testDifferencePathReplicated() {
+        let mock = Snapshot(data: .init(), path: .mocks)
+        let replicated = try? mock.replicated(path: CollectionPaths.mocks.document("replicated"))
+        XCTAssertNotNil(replicated)
+        XCTAssertNotEqual(mock.path, replicated?.path)
+        XCTAssertEqual(mock.name, replicated?.name)
+        mock.name = "changed"
+        XCTAssertNotEqual(mock.name, replicated?.name)
+    }
+}

--- a/FireSnapshotTests/ReplicatedTests.swift
+++ b/FireSnapshotTests/ReplicatedTests.swift
@@ -11,7 +11,7 @@ private extension CollectionPaths {
     static let mocks = CollectionPath<Mock>("mocks")
 }
 
-private struct Mock: Codable, HasTimestamps {
+private struct Mock: Codable, HasTimestamps, Equatable {
     var name: String = "Mike"
 }
 
@@ -32,6 +32,7 @@ class ReplicatedTests: XCTestCase {
         XCTAssertNotNil(replicated)
         XCTAssertEqual(mock.path, replicated?.path)
         XCTAssertEqual(mock.name, replicated?.name)
+        XCTAssertEqual(mock, replicated)
         mock.name = "changed"
         XCTAssertNotEqual(mock.name, replicated?.name)
     }
@@ -53,6 +54,7 @@ class ReplicatedTests: XCTestCase {
                         XCTAssertNotNil(replicated?.updateTime)
                         XCTAssertEqual(m.createTime, replicated?.createTime)
                         XCTAssertEqual(m.updateTime, replicated?.updateTime)
+                        XCTAssertEqual(mock, replicated)
                         XCTAssertEqual(m.path, replicated?.path)
                         XCTAssertEqual(m.name, replicated?.name)
                         exp.fulfill()
@@ -74,6 +76,7 @@ class ReplicatedTests: XCTestCase {
         XCTAssertNotNil(replicated)
         XCTAssertNotEqual(mock.path, replicated?.path)
         XCTAssertEqual(mock.name, replicated?.name)
+        XCTAssertNotEqual(mock, replicated)
         mock.name = "changed"
         XCTAssertNotEqual(mock.name, replicated?.name)
     }


### PR DESCRIPTION
I just implemented `.replicated()` method.
Snapshot can repliate new object that have same data and same path or specified path.


```swift
private extension CollectionPaths {
    static let mocks = CollectionPath<Mock>("mocks")
}

private struct Mock: Codable, Equatable, HasTimestamps {
    var name: String = "Mike"
}

let mock = Snapshot(data: .init(), path: .mocks)
let replicated = try! mock.replicated()

print(mock.path == replicated.path) // true
print(mock.name == replicated.name) // true
print(mock == replicated)

mock.name = "changed"

print(mock.name == replicated.name) // false
```