### PR TITLE
Define SnapshotData protocol

### DIFF
--- a/FireSnapshot.xcodeproj/project.pbxproj
+++ b/FireSnapshot.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		1659EBF423433F9300BD510D /* AtomicArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1659EBF323433F9300BD510D /* AtomicArray.swift */; };
 		1659EBF6234446B900BD510D /* DeletableField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1659EBF5234446B900BD510D /* DeletableField.swift */; };
 		1694DF5F234D78E800B7807A /* ReplicatedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1694DF5E234D78E800B7807A /* ReplicatedTests.swift */; };
+		1694DF63234DA1C400B7807A /* SnapshotData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1694DF62234DA1C400B7807A /* SnapshotData.swift */; };
 		16B699E4234636DD005877A9 /* CollectionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B699E3234636DD005877A9 /* CollectionGroup.swift */; };
 		16B699E82348CA80005877A9 /* PathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B699E72348CA80005877A9 /* PathTests.swift */; };
 		C7AC0728461714610F570CB5 /* Pods_FireSnapshotTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA9C3F24DAB7C0106A5A122D /* Pods_FireSnapshotTests.framework */; };
@@ -105,6 +106,7 @@
 		1659EBF323433F9300BD510D /* AtomicArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicArray.swift; sourceTree = "<group>"; };
 		1659EBF5234446B900BD510D /* DeletableField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletableField.swift; sourceTree = "<group>"; };
 		1694DF5E234D78E800B7807A /* ReplicatedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplicatedTests.swift; sourceTree = "<group>"; };
+		1694DF62234DA1C400B7807A /* SnapshotData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotData.swift; sourceTree = "<group>"; };
 		16B699E3234636DD005877A9 /* CollectionGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionGroup.swift; sourceTree = "<group>"; };
 		16B699E72348CA80005877A9 /* PathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathTests.swift; sourceTree = "<group>"; };
 		25B42645485A6D1C6682724A /* Pods-FireSnapshot.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FireSnapshot.debug.xcconfig"; path = "Target Support Files/Pods-FireSnapshot/Pods-FireSnapshot.debug.xcconfig"; sourceTree = "<group>"; };
@@ -188,6 +190,7 @@
 				1659EBF323433F9300BD510D /* AtomicArray.swift */,
 				1659EBF5234446B900BD510D /* DeletableField.swift */,
 				16B699E3234636DD005877A9 /* CollectionGroup.swift */,
+				1694DF62234DA1C400B7807A /* SnapshotData.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -438,6 +441,7 @@
 				1659EBEA234113D900BD510D /* Reference.swift in Sources */,
 				1659EBF02341CBEE00BD510D /* WriteBatch+Snapshot.swift in Sources */,
 				1617CD572340CB1700099FC5 /* WriteBatch+WriteEncodable.swift in Sources */,
+				1694DF63234DA1C400B7807A /* SnapshotData.swift in Sources */,
 				1617CD672340CC9100099FC5 /* FirestoreEncoder.swift in Sources */,
 				1617CD612340CB1700099FC5 /* GeoPoint+Codable.swift in Sources */,
 				1659EBF423433F9300BD510D /* AtomicArray.swift in Sources */,

--- a/FireSnapshot/Sources/CollectionGroup.swift
+++ b/FireSnapshot/Sources/CollectionGroup.swift
@@ -10,7 +10,7 @@ public class CollectionGroups {
     }
 }
 
-public class CollectionGroup<T>: CollectionGroups where T: Codable {
+public class CollectionGroup<T>: CollectionGroups where T: SnapshotData {
     public let collectionID: String
     public init(_ collectionID: String) {
         self.collectionID = collectionID

--- a/FireSnapshot/Sources/FieldNameReferable.swift
+++ b/FireSnapshot/Sources/FieldNameReferable.swift
@@ -8,7 +8,7 @@ public protocol FieldNameReferable {
     static var fieldNames: [PartialKeyPath<Self>: String] { get }
 }
 
-public extension FieldNameReferable {
+public extension FieldNameReferable where Self: SnapshotData {
     static func fieldName(from keyPath: PartialKeyPath<Self>) -> String? {
         return fieldNames[keyPath]
     }

--- a/FireSnapshot/Sources/Path.swift
+++ b/FireSnapshot/Sources/Path.swift
@@ -52,14 +52,14 @@ extension FirestorePath where Self: CollectionPaths {
     }
 }
 
-public class DocumentPath<T>: DocumentPaths, FirestorePath where T: Codable {
+public class DocumentPath<T>: DocumentPaths, FirestorePath where T: SnapshotData {
     public let path: String
 
     fileprivate convenience init(_ collectionPath: String, _ documentID: String) {
         self.init([collectionPath, documentID].joined(separator: "/"))
     }
 
-    fileprivate convenience init<U>(_ collectionPath: CollectionPath<U>, _ documentID: String) where U: Codable {
+    fileprivate convenience init<U>(_ collectionPath: CollectionPath<U>, _ documentID: String) where U: SnapshotData {
         self.init(collectionPath.path, documentID)
     }
 
@@ -71,7 +71,7 @@ public class DocumentPath<T>: DocumentPaths, FirestorePath where T: Codable {
         CollectionPath(self, collectionName)
     }
 
-    public func collection<U>(_ collectionName: String) -> CollectionPath<U> where U: Codable{
+    public func collection<U>(_ collectionName: String) -> CollectionPath<U> where U: SnapshotData {
         CollectionPath(self, collectionName)
     }
 
@@ -84,14 +84,14 @@ public class DocumentPath<T>: DocumentPaths, FirestorePath where T: Codable {
     }
 }
 
-public class CollectionPath<T>: CollectionPaths, FirestorePath where T: Codable {
+public class CollectionPath<T>: CollectionPaths, FirestorePath where T: SnapshotData {
     public let path: String
 
     fileprivate convenience init(_ documentPath: String, _ collectionName: String) {
         self.init([documentPath, collectionName].joined(separator: "/"))
     }
 
-    fileprivate convenience init<U>(_ documentPath: DocumentPath<U>, _ collectionName: String) where U: Codable {
+    fileprivate convenience init<U>(_ documentPath: DocumentPath<U>, _ collectionName: String) where U: SnapshotData {
         self.init(documentPath.path, collectionName)
     }
 
@@ -103,7 +103,7 @@ public class CollectionPath<T>: CollectionPaths, FirestorePath where T: Codable 
         DocumentPath(self, documentID)
     }
 
-    public func document<U>(_ documentID: String) -> DocumentPath<U> where U: Codable {
+    public func document<U>(_ documentID: String) -> DocumentPath<U> where U: SnapshotData {
         DocumentPath(self, documentID)
     }
 
@@ -131,7 +131,7 @@ public class AnyDocumentPath: DocumentPaths, FirestorePath {
         self.init([collectionPath, documentID].joined(separator: "/"))
     }
 
-    fileprivate convenience init<T>(_ collectionPath: CollectionPath<T>, _ documentID: String) where T: Codable {
+    fileprivate convenience init<T>(_ collectionPath: CollectionPath<T>, _ documentID: String) where T: SnapshotData {
         self.init(collectionPath.path, documentID)
     }
 
@@ -147,7 +147,7 @@ public class AnyDocumentPath: DocumentPaths, FirestorePath {
         AnyCollectionPath(self.path, collectionName)
     }
 
-    public func collection<T>(_ collectionName: String) -> CollectionPath<T> where T: Codable {
+    public func collection<T>(_ collectionName: String) -> CollectionPath<T> where T: SnapshotData {
         CollectionPath(self.path, collectionName)
     }
 
@@ -163,7 +163,7 @@ public class AnyCollectionPath: CollectionPaths, FirestorePath {
         self.init([documentPath, collectionName].joined(separator: "/"))
     }
 
-    fileprivate convenience init<T>(_ documentPath: DocumentPath<T>, _ collectionName: String) where T: Codable {
+    fileprivate convenience init<T>(_ documentPath: DocumentPath<T>, _ collectionName: String) where T: SnapshotData {
         self.init(documentPath.path, collectionName)
     }
 
@@ -179,7 +179,7 @@ public class AnyCollectionPath: CollectionPaths, FirestorePath {
         AnyDocumentPath(self.path, documentID)
     }
 
-    public func document<T>(_ documentID: String) -> DocumentPath<T> where T: Codable {
+    public func document<T>(_ documentID: String) -> DocumentPath<T> where T: SnapshotData {
         DocumentPath(self.path, documentID)
     }
 

--- a/FireSnapshot/Sources/QueryBuilder.swift
+++ b/FireSnapshot/Sources/QueryBuilder.swift
@@ -5,7 +5,7 @@
 import Foundation
 import FirebaseFirestore
 
-public final class QueryBuilder<D> where D: FieldNameReferable {
+public final class QueryBuilder<D> where D: SnapshotData, D: FieldNameReferable {
     private(set) var query: Query
     public init(_ query: Query) {
         self.query = query

--- a/FireSnapshot/Sources/Reference.swift
+++ b/FireSnapshot/Sources/Reference.swift
@@ -6,7 +6,7 @@ import Foundation
 import FirebaseFirestore
 
 @propertyWrapper
-public struct Reference<D>: Codable  where D: Codable {
+public struct Reference<D>: Codable where D: SnapshotData {
     public private(set) var wrappedValue: DocumentReference
     public init(wrappedValue: DocumentReference) {
         self.wrappedValue = wrappedValue

--- a/FireSnapshot/Sources/Snapshot+Read.swift
+++ b/FireSnapshot/Sources/Snapshot+Read.swift
@@ -7,8 +7,8 @@ import FirebaseFirestore
 
 public extension Snapshot {
     typealias QueryBuilder = (Query) -> Query
-    typealias DocumentReadResultBlock<T: Codable> = (Result<Snapshot<T>, Error>) -> Void
-    typealias CollectionReadResultBlock<T: Codable> = (Result<[Snapshot<T>], Error>) -> Void
+    typealias DocumentReadResultBlock<T: SnapshotData> = (Result<Snapshot<T>, Error>) -> Void
+    typealias CollectionReadResultBlock<T: SnapshotData> = (Result<[Snapshot<T>], Error>) -> Void
 
     static func get(_ path: DocumentPath<Data>,
                     source: FirestoreSource = .default,

--- a/FireSnapshot/Sources/Snapshot.swift
+++ b/FireSnapshot/Sources/Snapshot.swift
@@ -6,11 +6,11 @@ import FirebaseFirestore
 import Foundation
 
 public protocol SnapshotType {
-    associatedtype Data: Codable
+    associatedtype Data: SnapshotData
 }
 
 @dynamicMemberLookup
-public final class Snapshot<D>: SnapshotType where D: Codable {
+public final class Snapshot<D>: SnapshotType where D: SnapshotData {
     public typealias Data = D
     public typealias DataFactory = (DocumentReference) -> D
     public private(set) var data: D

--- a/FireSnapshot/Sources/SnapshotData.swift
+++ b/FireSnapshot/Sources/SnapshotData.swift
@@ -1,0 +1,8 @@
+//
+// Copyright © Suguru Kishimoto. All rights reserved.
+//
+
+import Foundation
+
+public protocol SnapshotData: Codable {
+}

--- a/FireSnapshotTests/AtomicArrayTests.swift
+++ b/FireSnapshotTests/AtomicArrayTests.swift
@@ -11,7 +11,7 @@ private extension CollectionPaths {
     static let mocks = CollectionPath<Mock>("mocks")
 }
 
-private struct Mock: Codable {
+private struct Mock: SnapshotData {
     @AtomicArray var languages: [String] = ["ja"]
 }
 

--- a/FireSnapshotTests/FireSnapshotTests.swift
+++ b/FireSnapshotTests/FireSnapshotTests.swift
@@ -7,13 +7,13 @@ import FirebaseFirestore
 
 @testable import FireSnapshot
 
-private struct Task: Codable {
+private struct Task: SnapshotData {
     var name: String = "test"
     @AtomicArray var userNames: [String] = []
     var bio: DeletableField<String>? = .init(value: "Hogeeeeeeeeeeeeee!")
 }
 
-private struct User: Codable, HasTimestamps, FieldNameReferable {
+private struct User: SnapshotData, HasTimestamps, FieldNameReferable {
     var id: SelfDocumentID = .init()
     var name: String = "google"
     @IncrementableInt var count: Int64 = 10

--- a/FireSnapshotTests/IncrementableNumberTests.swift
+++ b/FireSnapshotTests/IncrementableNumberTests.swift
@@ -11,7 +11,7 @@ private extension CollectionPaths {
     static let mocks = CollectionPath<Mock>("mocks")
 }
 
-private struct Mock: Codable {
+private struct Mock: SnapshotData {
     @IncrementableInt var count: Int64 = 5
     @IncrementableDouble var distance: Double = 5.0
 }

--- a/FireSnapshotTests/PathTests.swift
+++ b/FireSnapshotTests/PathTests.swift
@@ -7,7 +7,7 @@ import FirebaseFirestore
 
 @testable import FireSnapshot
 
-private struct Mock: Codable {
+private struct Mock: SnapshotData {
 }
 
 class PathTests: XCTestCase {

--- a/FireSnapshotTests/ReplicatedTests.swift
+++ b/FireSnapshotTests/ReplicatedTests.swift
@@ -11,7 +11,7 @@ private extension CollectionPaths {
     static let mocks = CollectionPath<Mock>("mocks")
 }
 
-private struct Mock: Codable, HasTimestamps, Equatable {
+private struct Mock: SnapshotData, HasTimestamps, Equatable {
     var name: String = "Mike"
 }
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Firebase Cloud Firestore Model Framework using Codable.
 🚧
 
 ```swift
-// Define model that is adopted `Codable`
-struct User: Codable {
+// Define model and conform to protocol `SnapshotData`.
+struct User: SnapshotData {
     var name: String
 }
 


### PR DESCRIPTION
- Define `SnapshotData` protocol: inherit `Codable` protocol.
  - Snapshot's `Data` type must conform to `SnapshotData` protocol.
- Use `SnapshotData` instead of `Codable`.

### Before

```swift
struct Task: Codable {
    var name: String
}
```

### After

```swift
struct Task: SnapshotData {
    var name: String
}
```