### PR TITLE
Introduced Batch

### DIFF
--- a/FireSnapshot.xcodeproj/project.pbxproj
+++ b/FireSnapshot.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		1694DF77234EF66100B7807A /* QueryBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1694DF76234EF66100B7807A /* QueryBuilderTests.swift */; };
 		1694DF79234F04C700B7807A /* WriteTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1694DF78234F04C700B7807A /* WriteTest.swift */; };
 		1694DF7B234F11C600B7807A /* ResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1694DF7A234F11C600B7807A /* ResultTests.swift */; };
+		1694DF7F235003A400B7807A /* Batch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1694DF7E235003A400B7807A /* Batch.swift */; };
 		16B699E4234636DD005877A9 /* CollectionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B699E3234636DD005877A9 /* CollectionGroup.swift */; };
 		16B699E82348CA80005877A9 /* PathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B699E72348CA80005877A9 /* PathTests.swift */; };
 		C7AC0728461714610F570CB5 /* Pods_FireSnapshotTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA9C3F24DAB7C0106A5A122D /* Pods_FireSnapshotTests.framework */; };
@@ -127,6 +128,7 @@
 		1694DF76234EF66100B7807A /* QueryBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryBuilderTests.swift; sourceTree = "<group>"; };
 		1694DF78234F04C700B7807A /* WriteTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteTest.swift; sourceTree = "<group>"; };
 		1694DF7A234F11C600B7807A /* ResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
+		1694DF7E235003A400B7807A /* Batch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Batch.swift; sourceTree = "<group>"; };
 		16B699E3234636DD005877A9 /* CollectionGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionGroup.swift; sourceTree = "<group>"; };
 		16B699E72348CA80005877A9 /* PathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathTests.swift; sourceTree = "<group>"; };
 		25B42645485A6D1C6682724A /* Pods-FireSnapshot.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FireSnapshot.debug.xcconfig"; path = "Target Support Files/Pods-FireSnapshot/Pods-FireSnapshot.debug.xcconfig"; sourceTree = "<group>"; };
@@ -212,6 +214,7 @@
 				16B699E3234636DD005877A9 /* CollectionGroup.swift */,
 				1694DF62234DA1C400B7807A /* SnapshotData.swift */,
 				1694DF68234DDF0D00B7807A /* DocumentReference+.swift */,
+				1694DF7E235003A400B7807A /* Batch.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -458,6 +461,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1694DF7F235003A400B7807A /* Batch.swift in Sources */,
 				1607A5BC233F4A550034BB35 /* SnapshotError.swift in Sources */,
 				1617CD5C2340CB1700099FC5 /* CodablePassThroughTypes.swift in Sources */,
 				1607A5BA233F42580034BB35 /* DocumentTimestamps.swift in Sources */,

--- a/FireSnapshot/Sources/Batch.swift
+++ b/FireSnapshot/Sources/Batch.swift
@@ -1,0 +1,63 @@
+//
+// Copyright © Suguru Kishimoto. All rights reserved.
+//
+
+import Foundation
+import FirebaseFirestore
+
+public final class Batch {
+    enum SnapshotBag {
+        typealias FieldExtractBlock = () throws -> [String: Any]
+
+        case create(reference: DocumentReference, extractor: FieldExtractBlock)
+        case update(reference: DocumentReference, extractor: FieldExtractBlock)
+        case delete(reference: DocumentReference)
+    }
+
+    private var bags: [SnapshotBag] = []
+    public init() {
+    }
+
+    @discardableResult
+    public func create<D>(_ snapshot: Snapshot<D>) -> Self where D: SnapshotData {
+        bags.append(.create(reference: snapshot.reference, extractor: {
+            try snapshot.extractWriteFieldsForCreate()
+        }))
+        return self
+    }
+
+    @discardableResult
+    public func update<D>(_ snapshot: Snapshot<D>) -> Self where D: SnapshotData {
+        bags.append(.update(reference: snapshot.reference, extractor: { try snapshot.extractWriteFieldsForUpdate() }))
+        return self
+    }
+
+    @discardableResult
+    public func delete<D>(_ snapshot: Snapshot<D>) -> Self where D: SnapshotData {
+        bags.append(.delete(reference: snapshot.reference))
+        return self
+    }
+
+    public func commit(completion: @escaping (Error?) -> Void) {
+        do {
+            (try asWriteBatch()).commit(completion: completion)
+        } catch {
+            completion(error)
+        }
+    }
+
+    public func asWriteBatch() throws -> WriteBatch {
+        let batch = Firestore.firestore().batch()
+        try bags.forEach { bag in
+            switch bag {
+            case let .create(reference, extractor):
+                batch.setData(try extractor(), forDocument: reference)
+            case let .update(reference, extractor):
+                batch.updateData(try extractor(), forDocument: reference)
+            case let .delete(reference):
+                batch.deleteDocument(reference)
+            }
+        }
+        return batch
+    }
+}

--- a/FireSnapshot/Sources/Transaction+Snapshot.swift
+++ b/FireSnapshot/Sources/Transaction+Snapshot.swift
@@ -11,11 +11,6 @@ extension Transaction {
     }
 
     func create<D>(_ snapshot: Snapshot<D>) throws {
-        var fields = try Firestore.Encoder().encode(snapshot.data)
-        if snapshot.data is HasTimestamps {
-            fields[SnapshotTimestampKey.createTime.rawValue] = FieldValue.serverTimestamp()
-            fields[SnapshotTimestampKey.updateTime.rawValue] = FieldValue.serverTimestamp()
-        }
         setData(try snapshot.extractWriteFieldsForCreate(), forDocument: snapshot.reference)
     }
 

--- a/FireSnapshot/Sources/WriteBatch+Snapshot.swift
+++ b/FireSnapshot/Sources/WriteBatch+Snapshot.swift
@@ -7,11 +7,6 @@ import FirebaseFirestore
 
 extension WriteBatch {
     func create<D>(_ snapshot: Snapshot<D>) throws {
-        var fields = try Firestore.Encoder().encode(snapshot.data)
-        if snapshot.data is HasTimestamps {
-            fields[SnapshotTimestampKey.createTime.rawValue] = FieldValue.serverTimestamp()
-            fields[SnapshotTimestampKey.updateTime.rawValue] = FieldValue.serverTimestamp()
-        }
         setData(try snapshot.extractWriteFieldsForCreate(), forDocument: snapshot.reference)
     }
 

--- a/FireSnapshotTests/BatchTests.swift
+++ b/FireSnapshotTests/BatchTests.swift
@@ -47,6 +47,38 @@ class BatchTests: XCTestCase {
         let user = Snapshot(data: .init(), path: .users)
         let task = Snapshot(data: .init(), path: .tasks)
 
+        let batch = Batch()
+            .create(user)
+            .create(task)
+
+        batch.commit { error in
+            if error != nil {
+                XCTFail()
+                exp.fulfill()
+            }
+            let mock = Snapshot(data: .init(), path: .mocks)
+            user.name = "John"
+
+            let batch = Batch()
+                .update(user)
+                .delete(task)
+                .create(mock)
+
+            batch.commit { error in
+                if error != nil {
+                    XCTFail()
+                }
+                exp.fulfill()
+            }
+        }
+        wait(for: [exp], timeout: 10.0)
+    }
+
+    func testSuccessWriteWithExtension() {
+        let exp = expectation(description: #function)
+        let user = Snapshot(data: .init(), path: .users)
+        let task = Snapshot(data: .init(), path: .tasks)
+
         let batch = Firestore.firestore().batch()
         try! batch.create(user)
         try! batch.create(task)
@@ -79,9 +111,9 @@ class BatchTests: XCTestCase {
         let user = Snapshot(data: .init(), path: .users)
         let invalid = Snapshot(data: .init(), path: .invalids)
 
-        let batch = Firestore.firestore().batch()
-        try! batch.create(user)
-        try! batch.create(invalid)
+        let batch = Batch()
+            .create(user)
+            .create(invalid)
 
         batch.commit { error in
             if error == nil {

--- a/FireSnapshotTests/CollectionGroupTests.swift
+++ b/FireSnapshotTests/CollectionGroupTests.swift
@@ -53,9 +53,9 @@ class CollectionGroupTests: XCTestCase {
         let user = Snapshot(data: .init(), path: .users)
         let task = Snapshot(data: .init(), path: .tasks)
 
-        let batch = Firestore.firestore().batch()
-        try! batch.create(user)
-        try! batch.create(task)
+        let batch = Batch()
+            .create(user)
+            .create(task)
         batch.commit { error in
             if let error = error {
                 XCTFail("\(error)")
@@ -66,9 +66,9 @@ class CollectionGroupTests: XCTestCase {
             g1.name = "from user"
             let g2 = Snapshot(data: .init(), path: .groups(for: task.path))
             g2.name = "from task"
-            let batch = Firestore.firestore().batch()
-            try! batch.create(g1)
-            try! batch.create(g2)
+            let batch = Batch()
+                .create(g1)
+                .create(g2)
 
             batch.commit { error in
                 if let error = error {

--- a/FireSnapshotTests/IncrementableNumberTests.swift
+++ b/FireSnapshotTests/IncrementableNumberTests.swift
@@ -33,9 +33,10 @@ class IncrementableNumberTests: XCTestCase {
         exp.expectedFulfillmentCount = 2
         let mock1 = Snapshot(data: .init(), path: .mocks)
         let mock2 = Snapshot(data: .init(), path: .mocks)
-        let batch = Firestore.firestore().batch()
-        try! batch.create(mock1)
-        try! batch.create(mock2)
+        let batch = Batch()
+            .create(mock1)
+            .create(mock2)
+
         batch.commit { error in
             if let error = error {
                 XCTFail("\(error)")

--- a/FireSnapshotTests/QueryBuilderTests.swift
+++ b/FireSnapshotTests/QueryBuilderTests.swift
@@ -170,9 +170,9 @@ class QueryBuilderTests: XCTestCase {
         let mock2 = Snapshot(data: .init(), path: .mocks)
         mock2.count = 15
 
-        let batch = Firestore.firestore().batch()
-        try! batch.create(mock1)
-        try! batch.create(mock2)
+        let batch = Batch()
+            .create(mock1)
+            .create(mock2)
 
         batch.commit { error in
             if let error = error {
@@ -201,9 +201,9 @@ class QueryBuilderTests: XCTestCase {
         let mock2 = Snapshot(data: .init(), path: .mocks)
         mock2.count = 15
 
-        let batch = Firestore.firestore().batch()
-        try! batch.create(mock1)
-        try! batch.create(mock2)
+        let batch = Batch()
+            .create(mock1)
+            .create(mock2)
 
         batch.commit { error in
             if let error = error {

--- a/FireSnapshotTests/ReadTests.swift
+++ b/FireSnapshotTests/ReadTests.swift
@@ -127,9 +127,9 @@ class ReadTests: XCTestCase {
         let mock2 = Snapshot(data: .init(), path: .mocks)
         mock2.name = "xyz"
 
-        let batch = Firestore.firestore().batch()
-        try! batch.create(mock1)
-        try! batch.create(mock2)
+        let batch = Batch()
+            .create(mock1)
+            .create(mock2)
         batch.commit { error in
             if let error = error {
                 XCTFail("\(error)")
@@ -178,9 +178,9 @@ class ReadTests: XCTestCase {
         let mock2 = Snapshot(data: .init(), path: .mocks)
         mock2.name = "xyz"
 
-        let batch = Firestore.firestore().batch()
-        try! batch.create(mock1)
-        try! batch.create(mock2)
+        let batch = Batch()
+            .create(mock1)
+            .create(mock2)
         batch.commit { error in
             if let error = error {
                 XCTFail("\(error)")

--- a/FireSnapshotTests/TransactionTests.swift
+++ b/FireSnapshotTests/TransactionTests.swift
@@ -40,9 +40,9 @@ class TransactionTests: XCTestCase {
         let mock2 = Snapshot(data: .init(), path: .mocks)
         let mock3 = Snapshot(data: .init(), path: .mocks)
 
-        let batch = Firestore.firestore().batch()
-        try! batch.create(mock1)
-        try! batch.create(mock2)
+        let batch = Batch()
+            .create(mock1)
+            .create(mock2)
 
         batch.commit { error in
             if let error = error {


### PR DESCRIPTION
Introduced `Batch` class. It can avoid `try` keyword on `create/update` compared to `Batch+Extension`.

- Before

```swift
let batch = Firestore.firestore().batch()
try! batch.create(user)
try! batch.create(task)
```

- After

```swift
let batch = Batch()
    .create(user)
    .create(task) // It can method chain style.

batch.commit{ error in
    // Emit error if extracting snapshot failed or `commit` failed.
}
```