### PR TITLE
Improved path handling.

### DIFF
--- a/FireSnapshot/Sources/Path.swift
+++ b/FireSnapshot/Sources/Path.swift
@@ -82,6 +82,14 @@ public class DocumentPath<T>: DocumentPaths, FirestorePath where T: SnapshotData
         documentReference.documentID
     }
 
+    public func sameIDSubDocument(_ collectionName: String) -> DocumentPath<T> {
+        collection(collectionName).document(id)
+    }
+
+    public func sameIDSubDocument<U>(_ collectionName: String) -> DocumentPath<U> where U: SnapshotData {
+        collection(collectionName).document(id)
+    }
+
     public static func == (lhs: DocumentPath<T>, rhs: DocumentPath<T>) -> Bool {
         lhs.path == rhs.path
     }
@@ -156,6 +164,14 @@ public class AnyDocumentPath: DocumentPaths, FirestorePath {
 
     public func collection<T>(_ collectionName: String) -> CollectionPath<T> where T: SnapshotData {
         CollectionPath(self.path, collectionName)
+    }
+
+    public func anySameIDSubDocument(_ collectionName: String) -> AnyDocumentPath {
+        anyCollection(collectionName).anyDocument(id)
+    }
+
+    public func sameIDSubDocument<U>(_ collectionName: String) -> DocumentPath<U> where U: SnapshotData {
+        collection(collectionName).document(id)
     }
 
     public var documentReference: DocumentReference {

--- a/FireSnapshot/Sources/Path.swift
+++ b/FireSnapshot/Sources/Path.swift
@@ -78,6 +78,10 @@ public class DocumentPath<T>: DocumentPaths, FirestorePath where T: SnapshotData
         Firestore.firestore().document(path)
     }
 
+    public var id: String {
+        documentReference.documentID
+    }
+
     public static func == (lhs: DocumentPath<T>, rhs: DocumentPath<T>) -> Bool {
         lhs.path == rhs.path
     }
@@ -108,6 +112,10 @@ public class CollectionPath<T>: CollectionPaths, FirestorePath where T: Snapshot
 
     public var collectionReference: CollectionReference {
         Firestore.firestore().collection(path)
+    }
+
+    public var id: String {
+        collectionReference.collectionID
     }
 
     public func documentRefernce(id: String? = nil) -> DocumentReference {
@@ -150,6 +158,14 @@ public class AnyDocumentPath: DocumentPaths, FirestorePath {
         CollectionPath(self.path, collectionName)
     }
 
+    public var documentReference: DocumentReference {
+        Firestore.firestore().document(path)
+    }
+
+    public var id: String {
+        documentReference.documentID
+    }
+
     public static func == (lhs: AnyDocumentPath, rhs: AnyDocumentPath) -> Bool {
         lhs.path == rhs.path
     }
@@ -180,6 +196,14 @@ public class AnyCollectionPath: CollectionPaths, FirestorePath {
 
     public func document<T>(_ documentID: String) -> DocumentPath<T> where T: SnapshotData {
         DocumentPath(self.path, documentID)
+    }
+
+    public var collectionReference: CollectionReference {
+        Firestore.firestore().collection(path)
+    }
+
+    public var id: String {
+        collectionReference.collectionID
     }
 
     public static func == (lhs: AnyCollectionPath, rhs: AnyCollectionPath) -> Bool {

--- a/FireSnapshotTests/Sources/PathTests.swift
+++ b/FireSnapshotTests/Sources/PathTests.swift
@@ -14,10 +14,12 @@ class PathTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        FirebaseTestHelper.setupFirebaseApp()
     }
 
     override func tearDown() {
         super.tearDown()
+        FirebaseTestHelper.deleteFirebaseApp()
     }
 
     func testDocumentPath() {
@@ -41,6 +43,11 @@ class PathTests: XCTestCase {
 
         XCTAssertEqual(DocumentPath<Mock>("mocks/xxx"), DocumentPath<Mock>("mocks/xxx"))
         XCTAssertNotEqual(DocumentPath<Mock>("mocks/xxx"), DocumentPath<Mock>("mocks/yyy"))
+
+        XCTAssertEqual(DocumentPath<Mock>("mocks/xxx").documentReference, Firestore.firestore().document("mocks/xxx"))
+        XCTAssertEqual(DocumentPath<Mock>("mocks/xxx/sub/yyy").documentReference, Firestore.firestore().document("mocks/xxx/sub/yyy"))
+        XCTAssertEqual(DocumentPath<Mock>("mocks/xxx").id, "xxx")
+        XCTAssertEqual(DocumentPath<Mock>("mocks/xxx/sub/yyy").id, "yyy")
     }
 
     func testCollectionPath() {
@@ -59,6 +66,11 @@ class PathTests: XCTestCase {
 
         XCTAssertEqual(CollectionPath<Mock>("mocks"), CollectionPath<Mock>("mocks"))
         XCTAssertNotEqual(CollectionPath<Mock>("mocks1"), CollectionPath<Mock>("mocks2"))
+
+        XCTAssertEqual(CollectionPath<Mock>("mocks").collectionReference, Firestore.firestore().collection("mocks"))
+        XCTAssertEqual(CollectionPath<Mock>("mocks/xxx/sub").collectionReference, Firestore.firestore().collection("mocks/xxx/sub"))
+        XCTAssertEqual(CollectionPath<Mock>("mocks").id, "mocks")
+        XCTAssertEqual(CollectionPath<Mock>("mocks/xxx/sub").id, "sub")
     }
 
     func testAnyDocumentPath() {
@@ -82,6 +94,11 @@ class PathTests: XCTestCase {
 
         XCTAssertEqual(AnyDocumentPath("mocks/xxx"), AnyDocumentPath("mocks/xxx"))
         XCTAssertNotEqual(AnyDocumentPath("mocks/xxx"), AnyDocumentPath("mocks/yyy"))
+
+        XCTAssertEqual(AnyDocumentPath("mocks/xxx").documentReference, Firestore.firestore().document("mocks/xxx"))
+        XCTAssertEqual(AnyDocumentPath("mocks/xxx/sub/yyy").documentReference, Firestore.firestore().document("mocks/xxx/sub/yyy"))
+        XCTAssertEqual(AnyDocumentPath("mocks/xxx").id, "xxx")
+        XCTAssertEqual(AnyDocumentPath("mocks/xxx/sub/yyy").id, "yyy")
     }
 
     func testAnyCollectionPath() {
@@ -100,5 +117,10 @@ class PathTests: XCTestCase {
 
         XCTAssertEqual(AnyCollectionPath("mocks"), AnyCollectionPath("mocks"))
         XCTAssertNotEqual(AnyCollectionPath("mocks1"), AnyCollectionPath("mocks2"))
+
+        XCTAssertEqual(AnyCollectionPath("mocks").collectionReference, Firestore.firestore().collection("mocks"))
+        XCTAssertEqual(AnyCollectionPath("mocks/xxx/sub").collectionReference, Firestore.firestore().collection("mocks/xxx/sub"))
+        XCTAssertEqual(AnyCollectionPath("mocks").id, "mocks")
+        XCTAssertEqual(AnyCollectionPath("mocks/xxx/sub").id, "sub")
     }
 }

--- a/FireSnapshotTests/Sources/PathTests.swift
+++ b/FireSnapshotTests/Sources/PathTests.swift
@@ -22,7 +22,8 @@ class PathTests: XCTestCase {
         FirebaseTestHelper.deleteFirebaseApp()
     }
 
-    func testDocumentPath() {
+    func test() {
+        // DocumentPath
         XCTAssertTrue(DocumentPath<Mock>("mocks/xxx").isValid)
         XCTAssertTrue(DocumentPath<Mock>("mocks/xxx/sub/yyy").isValid)
         XCTAssertTrue(CollectionPath<Mock>("mocks").document("xxx").isValid)
@@ -48,9 +49,12 @@ class PathTests: XCTestCase {
         XCTAssertEqual(DocumentPath<Mock>("mocks/xxx/sub/yyy").documentReference, Firestore.firestore().document("mocks/xxx/sub/yyy"))
         XCTAssertEqual(DocumentPath<Mock>("mocks/xxx").id, "xxx")
         XCTAssertEqual(DocumentPath<Mock>("mocks/xxx/sub/yyy").id, "yyy")
-    }
 
-    func testCollectionPath() {
+        XCTAssertEqual(DocumentPath<Mock>("mocks/xxx").sameIDSubDocument("sub").path, "mocks/xxx/sub/xxx")
+
+        // ==========================================
+        // CollectionPath
+
         XCTAssertTrue(CollectionPath<Mock>("mocks").isValid)
         XCTAssertTrue(CollectionPath<Mock>("mocks/xxx/sub").isValid)
         XCTAssertTrue(CollectionPath<Mock>("mocks").document("xxx").collection("sub").isValid)
@@ -71,13 +75,14 @@ class PathTests: XCTestCase {
         XCTAssertEqual(CollectionPath<Mock>("mocks/xxx/sub").collectionReference, Firestore.firestore().collection("mocks/xxx/sub"))
         XCTAssertEqual(CollectionPath<Mock>("mocks").id, "mocks")
         XCTAssertEqual(CollectionPath<Mock>("mocks/xxx/sub").id, "sub")
-    }
 
-    func testAnyDocumentPath() {
         XCTAssertTrue(AnyDocumentPath("mocks/xxx").isValid)
         XCTAssertTrue(AnyDocumentPath("mocks/xxx/sub/yyy").isValid)
         XCTAssertTrue(AnyCollectionPath("mocks").anyDocument("xxx").isValid)
         XCTAssertTrue(AnyCollectionPath("mocks").anyDocument("xxx").anyCollection("sub").anyDocument("yyy").isValid)
+
+        // ==========================================
+        // AnyDocumentPath
 
         XCTAssertFalse(AnyDocumentPath("").isValid)
         XCTAssertFalse(AnyDocumentPath("/").isValid)
@@ -99,9 +104,12 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AnyDocumentPath("mocks/xxx/sub/yyy").documentReference, Firestore.firestore().document("mocks/xxx/sub/yyy"))
         XCTAssertEqual(AnyDocumentPath("mocks/xxx").id, "xxx")
         XCTAssertEqual(AnyDocumentPath("mocks/xxx/sub/yyy").id, "yyy")
-    }
 
-    func testAnyCollectionPath() {
+        XCTAssertEqual(AnyDocumentPath("mocks/xxx").anySameIDSubDocument("sub").path, "mocks/xxx/sub/xxx")
+
+        // ==========================================
+        // AnyCollectionPath
+
         XCTAssertTrue(AnyCollectionPath("mocks").isValid)
         XCTAssertTrue(AnyCollectionPath("mocks/xxx/sub").isValid)
         XCTAssertTrue(AnyCollectionPath("mocks").anyDocument("xxx").anyCollection("sub").isValid)

--- a/FireSnapshotTests/Sources/ReadTests.swift
+++ b/FireSnapshotTests/Sources/ReadTests.swift
@@ -25,7 +25,7 @@ class ReadTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-         FirebaseTestHelper.setupFirebaseApp()
+        FirebaseTestHelper.setupFirebaseApp()
     }
 
     override func tearDown() {


### PR DESCRIPTION
- Implemented `DocumentPath.id`,  `AnyDocumentPath.id` to return `documentID`
- Implemented `CollectionPath.id`,  `AnyCollectionPath.id` to return `collectionID`

- Implemented `sameIDSubDocument`.  `DocumentPath<Model>("models/xxx").sameIDSubDocument("sub")` will be `"models/xxx/sub/xxx"`.