### PR TITLE
Renew reference storagepath

### DIFF
--- a/FireSnapshot.podspec
+++ b/FireSnapshot.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "FireSnapshot"
-  s.version          = "0.9.0"
+  s.version          = "0.10.0"
   s.summary          = "Firebase Cloud Firestore Model Framework using Codable."
   s.homepage         = "https://github.com/sgr-ksmt/#{s.name}"
   s.license          = 'MIT'

--- a/FireSnapshot/Sources/Core/Reference.swift
+++ b/FireSnapshot/Sources/Core/Reference.swift
@@ -5,19 +5,45 @@
 import FirebaseFirestore
 import Foundation
 
+public protocol ReferenceWrappable {
+    static func wrap(_ documentReference: DocumentReference) throws -> Self
+    static func unwrap(_ value: Self) throws -> DocumentReference
+}
+
+extension String: ReferenceWrappable {
+    public static func wrap(_ documentReference: DocumentReference) throws -> Self {
+        documentReference.path
+    }
+
+    public static func unwrap(_ value: Self) throws -> DocumentReference {
+        AnyDocumentPath(value).documentReference
+    }
+}
+
+extension DocumentReference: ReferenceWrappable {
+    public static func wrap(_ documentReference: DocumentReference) throws -> Self {
+        documentReference as! Self
+    }
+
+    public static func unwrap(_ value: DocumentReference) throws -> DocumentReference {
+        value
+    }
+}
+
 @propertyWrapper
-public struct Reference<D>: Codable, Equatable where D: SnapshotData {
-    public var wrappedValue: DocumentReference?
-    public init(wrappedValue: DocumentReference?) {
-        self.wrappedValue = wrappedValue
+public struct Reference<D, V>: Codable, Equatable where D: SnapshotData, V: ReferenceWrappable & Codable & Equatable {
+
+    private var value: V?
+    public init(wrappedValue value: V?) {
+        self.value = value
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if container.decodeNil() {
-            wrappedValue = nil
+            value = nil
         } else {
-            wrappedValue = try container.decode(DocumentReference.self)
+            value = try V.wrap(container.decode(DocumentReference.self))
         }
     }
 
@@ -26,23 +52,28 @@ public struct Reference<D>: Codable, Equatable where D: SnapshotData {
         try container.encode(wrappedValue)
     }
 
+    public var wrappedValue: V? {
+        get { value }
+        set { value = newValue }
+    }
+
     public var projectedValue: Self {
         self
     }
 
     public func get(source: FirestoreSource = .default, completion: @escaping Snapshot<D>.DocumentReadResultBlock<D>) {
-        guard let wrappedValue = wrappedValue else {
+        guard let ref = try? value.map(V.unwrap) else {
             completion(.failure(SnapshotError.notExists))
             return
         }
-        Snapshot<D>.get(wrappedValue, source: source, completion: completion)
+        Snapshot<D>.get(ref, source: source, completion: completion)
     }
 
     public func listen(includeMetadataChanges: Bool = false, completion: @escaping Snapshot<D>.DocumentReadResultBlock<D>) -> ListenerRegistration? {
-        guard let wrappedValue = wrappedValue else {
+        guard let ref = try? value.map(V.unwrap) else {
             completion(.failure(SnapshotError.notExists))
             return nil
         }
-        return Snapshot<D>.listen(wrappedValue, includeMetadataChanges: includeMetadataChanges, completion: completion)
+        return Snapshot<D>.listen(ref, includeMetadataChanges: includeMetadataChanges, completion: completion)
     }
 }

--- a/FireSnapshot/Sources/Core/Snapshot.swift
+++ b/FireSnapshot/Sources/Core/Snapshot.swift
@@ -62,7 +62,7 @@ public final class Snapshot<D>: SnapshotType where D: SnapshotData {
         }
     }
 
-    public subscript<V>(dynamicMember keyPath: KeyPath<D, Reference<V>>) -> Reference<V> where V: SnapshotData {
+    public subscript<T, U>(dynamicMember keyPath: KeyPath<D, Reference<T, U>>) -> Reference<T, U> where T: SnapshotData, U: ReferenceWrappable & Codable & Equatable {
         return data[keyPath: keyPath]
     }
 

--- a/FireSnapshot/Sources/Storage/StoragePath.swift
+++ b/FireSnapshot/Sources/Storage/StoragePath.swift
@@ -5,12 +5,12 @@
 import FirebaseStorage
 import Foundation
 
-public protocol StorageReferenceWrappable {
+public protocol StoragePathWrappable {
     static func wrap(_ storageReference: StorageReference) throws -> Self
     static func unwrap(_ value: Self) throws -> StorageReference
 }
 
-extension String: StorageReferenceWrappable {
+extension String: StoragePathWrappable {
     public static func wrap(_ storageReference: StorageReference) throws -> Self {
         storageReference.fullPath
     }
@@ -20,7 +20,7 @@ extension String: StorageReferenceWrappable {
     }
 }
 
-extension StorageReference: StorageReferenceWrappable {
+extension StorageReference: StoragePathWrappable {
     public static func wrap(_ storageReference: StorageReference) throws -> Self {
         storageReference as! Self
     }
@@ -31,8 +31,8 @@ extension StorageReference: StorageReferenceWrappable {
 }
 
 @propertyWrapper
-public struct StoragePath<V>: Codable, Equatable where V: StorageReferenceWrappable & Codable & Equatable {
-    var value: V?
+public struct StoragePath<V>: Codable, Equatable where V: StoragePathWrappable & Codable & Equatable {
+    private var value: V?
     public init(wrappedValue value: V?) {
         self.value = value
     }

--- a/FireSnapshot/Sources/Storage/StoragePath.swift
+++ b/FireSnapshot/Sources/Storage/StoragePath.swift
@@ -5,46 +5,59 @@
 import FirebaseStorage
 import Foundation
 
-@propertyWrapper
-public struct StoragePath: Codable, Equatable {
-    public var wrappedValue: StorageReference?
-    public init(wrappedValue: StorageReference?) {
-        self.wrappedValue = wrappedValue
+public protocol StorageReferenceWrappable {
+    static func wrap(_ storageReference: StorageReference) throws -> Self
+    static func unwrap(_ value: Self) throws -> StorageReference
+}
+
+extension String: StorageReferenceWrappable {
+    public static func wrap(_ storageReference: StorageReference) throws -> Self {
+        storageReference.fullPath
     }
 
-    public init(path: String) {
-        self.wrappedValue = Storage.storage().reference().child(path)
+    public static func unwrap(_ value: Self) throws -> StorageReference {
+        Storage.storage().reference().child(value)
+    }
+}
+
+extension StorageReference: StorageReferenceWrappable {
+    public static func wrap(_ storageReference: StorageReference) throws -> Self {
+        storageReference as! Self
+    }
+
+    public static func unwrap(_ value: StorageReference) throws -> StorageReference {
+        value
+    }
+}
+
+@propertyWrapper
+public struct StoragePath<V>: Codable, Equatable where V: StorageReferenceWrappable & Codable & Equatable {
+    var value: V?
+    public init(wrappedValue value: V?) {
+        self.value = value
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if container.decodeNil() {
-            wrappedValue = nil
+            value = nil
         } else {
-            wrappedValue = try Storage.storage().reference().child(container.decode(String.self))
+            value = try V.wrap(Storage.storage().reference().child(container.decode(String.self)))
         }
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(wrappedValue?.fullPath)
+        try container.encode(value.map(V.unwrap)?.fullPath)
     }
 
-    public var projectedValue: Self {
-        get {
-            self
-        }
-        set {
-            self = newValue
-        }
+
+    public var wrappedValue: V? {
+        get { value }
+        set { value = newValue }
     }
 
-    public var path: String? {
-        get {
-            wrappedValue?.fullPath
-        }
-        set {
-            wrappedValue = newValue.flatMap(Storage.storage().reference().child)
-        }
+    public var projectedValue: StorageReference? {
+        try? value.map(V.unwrap)
     }
 }

--- a/FireSnapshotTests/Sources/ReferenceTests.swift
+++ b/FireSnapshotTests/Sources/ReferenceTests.swift
@@ -18,7 +18,7 @@ private struct User: SnapshotData {
 
 private struct Task: SnapshotData {
     var title: String
-    @Reference<User> var author = nil
+    @Reference<User, DocumentReference> var author = nil
 }
 
 class ReferenceTests: XCTestCase {

--- a/FireSnapshotTests/Sources/StoragePathTests.swift
+++ b/FireSnapshotTests/Sources/StoragePathTests.swift
@@ -13,7 +13,7 @@ private extension CollectionPaths {
 }
 
 private struct Mock: SnapshotData, HasTimestamps {
-    @StoragePath(path: "path/to/image.jpg") var imageRef
+    @StoragePath var imageRef = "path/to/image.jpg"
 }
 
 class StoragePathTests: XCTestCase {
@@ -29,7 +29,7 @@ class StoragePathTests: XCTestCase {
 
     func testCodable() {
         let mock = Mock()
-        XCTAssertEqual(mock.imageRef, Storage.storage().reference().child("path/to/image.jpg"))
+        XCTAssertEqual(mock.$imageRef, Storage.storage().reference().child("path/to/image.jpg"))
         let fields = try? Firestore.Encoder().encode(mock)
         XCTAssertNotNil(fields)
         XCTAssertEqual(fields?["imageRef"] as? String, "path/to/image.jpg")
@@ -41,9 +41,9 @@ class StoragePathTests: XCTestCase {
 
     func testPath() {
         var mock = Mock()
-        XCTAssertEqual(mock.imageRef, Storage.storage().reference().child("path/to/image.jpg"))
+        XCTAssertEqual(mock.$imageRef, Storage.storage().reference().child("path/to/image.jpg"))
 
-        mock.$imageRef.path = "path/to/video.mp4"
-        XCTAssertEqual(mock.imageRef, Storage.storage().reference().child("path/to/video.mp4"))
+        mock.imageRef = "path/to/video.mp4"
+        XCTAssertEqual(mock.$imageRef, Storage.storage().reference().child("path/to/video.mp4"))
     }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -109,11 +109,11 @@ PODS:
   - gRPC-Core/Interface (1.21.0)
   - GTMSessionFetcher/Core (1.3.0)
   - leveldb-library (1.22)
-  - nanopb (0.3.904):
-    - nanopb/decode (= 0.3.904)
-    - nanopb/encode (= 0.3.904)
-  - nanopb/decode (0.3.904)
-  - nanopb/encode (0.3.904)
+  - nanopb (0.3.9011):
+    - nanopb/decode (= 0.3.9011)
+    - nanopb/encode (= 0.3.9011)
+  - nanopb/decode (0.3.9011)
+  - nanopb/encode (0.3.9011)
   - Protobuf (3.10.0)
 
 DEPENDENCIES:
@@ -166,9 +166,9 @@ SPEC CHECKSUMS:
   gRPC-Core: c9aef9a261a1247e881b18059b84d597293c9947
   GTMSessionFetcher: 43b8b64263023d4f32caa0b40f4c8bfa3c5f36d8
   leveldb-library: 55d93ee664b4007aac644a782d11da33fba316f7
-  nanopb: 06f6030d554e6473f5e172460173fcf80f5548f4
+  nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   Protobuf: a4dc852ad69c027ca2166ed287b856697814375b
 
 PODFILE CHECKSUM: a5366f43d9574017284729b1611b0c7f47ab9edb
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.8.1

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Snapshot.get(.products, queryBuilder: { builder in
 - CocoaPods
 
 ```ruby
-pod 'FireSnapshot', '~> 0.9.0'
+pod 'FireSnapshot', '~> 0.10.0'
 ```
 
 <hr />


### PR DESCRIPTION
Renew `@Reference` and `@StoragePath` with wrappeable.
So, we use also `String` instead of `DocumentReference` or `StorageReference`.

## After

```swift
@StoragePath var imageRef = "path/to/image.jpg"
@Reference<User, DocumentRefernce> author = nil
```