### PR TITLE
Support new queries(`array-contains-any` and `in`)

### DIFF
--- a/FireSnapshot/Sources/Core/QueryBuilder+Operator.swift
+++ b/FireSnapshot/Sources/Core/QueryBuilder+Operator.swift
@@ -68,3 +68,12 @@ public func > <D: SnapshotData & HasTimestamps>(lhs: SnapshotTimestampKey, rhs: 
 public func >= <D: SnapshotData & HasTimestamps>(lhs: SnapshotTimestampKey, rhs: Date) -> GreaterThanOrEqualTimestampPredicate<D> {
     .init(key: lhs, value: .init(date: rhs))
 }
+
+infix operator ~||
+public func ~|| <D: SnapshotData & FieldNameReferable, V: Equatable>(lhs: KeyPath<D, [V]>, rhs: [V]) -> ArrayContainsAnyPredicate<D, V> {
+    .init(keyPath: lhs, value: rhs)
+}
+
+public func || <D: SnapshotData & FieldNameReferable, V: Equatable>(lhs: KeyPath<D, V>, rhs: [V]) -> InPredicate<D, V> {
+    .init(keyPath: lhs, value: rhs)
+}

--- a/FireSnapshot/Sources/Core/QueryBuilder+Predicate.swift
+++ b/FireSnapshot/Sources/Core/QueryBuilder+Predicate.swift
@@ -5,97 +5,128 @@
 import FirebaseFirestore
 import Foundation
 
-public protocol WhereQueryPredicate {
+public protocol QueryPredicate {
     associatedtype Data: SnapshotData & FieldNameReferable
     associatedtype Value
+    associatedtype CompareValue
+}
 
+public protocol KeyPathQueryPredicate: QueryPredicate {
     var keyPath: KeyPath<Data, Value> { get }
-    var value: Value { get }
+    var value: CompareValue { get }
 }
 
-public protocol ArrayContainsWhereQueryPredicate {
-    associatedtype Data: SnapshotData & FieldNameReferable
-    associatedtype Value: Equatable
-
-    var keyPath: KeyPath<Data, [Value]> { get }
-    var value: Value { get }
+public protocol EqualQueryPredicate: KeyPathQueryPredicate where Value: Equatable, CompareValue == Value {
 }
 
-public struct EqualPredicate<D: SnapshotData & FieldNameReferable, V: Equatable>: WhereQueryPredicate {
+public protocol CompareQueryPredicate: EqualQueryPredicate where Value: Comparable {
+}
+
+public struct EqualPredicate<D: SnapshotData & FieldNameReferable, V: Equatable>: EqualQueryPredicate {
     public typealias Data = D
     public typealias Value = V
-    public var keyPath: KeyPath<D, V>
-    public var value: V
+    public typealias CompareValue = Value
+    public var keyPath: KeyPath<Data, Value>
+    public var value: CompareValue
 }
 
-public struct LessThanPredicate<D: SnapshotData & FieldNameReferable, V: Comparable>: WhereQueryPredicate {
+public struct LessThanPredicate<D: SnapshotData & FieldNameReferable, V: Comparable>: CompareQueryPredicate {
     public typealias Data = D
     public typealias Value = V
-    public var keyPath: KeyPath<D, V>
-    public var value: V
+    public typealias CompareValue = Value
+    public var keyPath: KeyPath<Data, Value>
+    public var value: CompareValue
 }
 
-public struct LessThanOrEqualPredicate<D: SnapshotData & FieldNameReferable, V: Comparable>: WhereQueryPredicate {
+public struct LessThanOrEqualPredicate<D: SnapshotData & FieldNameReferable, V: Comparable>: CompareQueryPredicate {
     public typealias Data = D
     public typealias Value = V
-    public var keyPath: KeyPath<D, V>
-    public var value: V
+    public typealias CompareValue = Value
+    public var keyPath: KeyPath<Data, Value>
+    public var value: CompareValue
 }
 
-public struct GreaterThanPredicate<D: SnapshotData & FieldNameReferable, V: Comparable>: WhereQueryPredicate {
+public struct GreaterThanPredicate<D: SnapshotData & FieldNameReferable, V: Comparable>: CompareQueryPredicate {
     public typealias Data = D
     public typealias Value = V
-    public var keyPath: KeyPath<D, V>
-    public var value: V
+    public typealias CompareValue = Value
+    public var keyPath: KeyPath<Data, Value>
+    public var value: CompareValue
 }
 
-public struct GreaterThanOrEqualPredicate<D: SnapshotData & FieldNameReferable, V: Comparable>: WhereQueryPredicate {
+public struct GreaterThanOrEqualPredicate<D: SnapshotData & FieldNameReferable, V: Comparable>: CompareQueryPredicate {
     public typealias Data = D
     public typealias Value = V
-    public var keyPath: KeyPath<D, V>
-    public var value: V
+    public typealias CompareValue = Value
+    public var keyPath: KeyPath<Data, Value>
+    public var value: CompareValue
 }
 
-public struct ArrayContainsPredicate<D: SnapshotData & FieldNameReferable, V: Equatable>: ArrayContainsWhereQueryPredicate {
+public struct ArrayContainsPredicate<D: SnapshotData & FieldNameReferable, V: Equatable>: QueryPredicate {
+    public typealias Data = D
+    public typealias Value = [V]
+    public typealias CompareValue = V
+    public var keyPath: KeyPath<Data, Value>
+    public var value: CompareValue
+}
+
+public struct ArrayContainsAnyPredicate<D: SnapshotData & FieldNameReferable, V: Equatable>: QueryPredicate {
+    public typealias Data = D
+    public typealias Value = [V]
+    public typealias CompareValue = Value
+    public var keyPath: KeyPath<Data, Value>
+    public var value: CompareValue
+}
+
+public struct InPredicate<D: SnapshotData & FieldNameReferable, V: Equatable>: QueryPredicate {
     public typealias Data = D
     public typealias Value = V
-    public var keyPath: KeyPath<D, [V]>
-    public var value: V
+    public typealias CompareValue = [V]
+    public var keyPath: KeyPath<Data, Value>
+    public var value: CompareValue
 }
 
-public protocol TimeStampWhereQueryPredicate {
-    associatedtype Data: SnapshotData & HasTimestamps
-
+public protocol TimestampQueryPredicate: QueryPredicate where CompareValue == Timestamp {
     var key: SnapshotTimestampKey { get }
-    var value: Timestamp { get }
+    var value: CompareValue { get }
 }
 
-public struct EqualTimestampPredicate<D: SnapshotData & HasTimestamps>: TimeStampWhereQueryPredicate {
+public struct EqualTimestampPredicate<D: SnapshotData & HasTimestamps & FieldNameReferable>: TimestampQueryPredicate {
     public typealias Data = D
+    public typealias Value = Timestamp
+    public typealias CompareValue = Value
     public var key: SnapshotTimestampKey
     public var value: Timestamp
 }
 
-public struct LessThanTimestampPredicate<D: SnapshotData & HasTimestamps>: TimeStampWhereQueryPredicate {
+public struct LessThanTimestampPredicate<D: SnapshotData & HasTimestamps & FieldNameReferable>: TimestampQueryPredicate {
     public typealias Data = D
+    public typealias Value = Timestamp
+    public typealias CompareValue = Value
     public var key: SnapshotTimestampKey
     public var value: Timestamp
 }
 
-public struct LessThanOrEqualTimestampPredicate<D: SnapshotData & HasTimestamps>: TimeStampWhereQueryPredicate {
+public struct LessThanOrEqualTimestampPredicate<D: SnapshotData & HasTimestamps & FieldNameReferable>: TimestampQueryPredicate {
     public typealias Data = D
+    public typealias Value = Timestamp
+    public typealias CompareValue = Value
     public var key: SnapshotTimestampKey
     public var value: Timestamp
 }
 
-public struct GreaterThanTimestampPredicate<D: SnapshotData & HasTimestamps>: TimeStampWhereQueryPredicate {
+public struct GreaterThanTimestampPredicate<D: SnapshotData & HasTimestamps & FieldNameReferable>: TimestampQueryPredicate {
     public typealias Data = D
+    public typealias Value = Timestamp
+    public typealias CompareValue = Value
     public var key: SnapshotTimestampKey
     public var value: Timestamp
 }
 
-public struct GreaterThanOrEqualTimestampPredicate<D: SnapshotData & HasTimestamps>: TimeStampWhereQueryPredicate {
+public struct GreaterThanOrEqualTimestampPredicate<D: SnapshotData & HasTimestamps & FieldNameReferable>: TimestampQueryPredicate {
     public typealias Data = D
+    public typealias Value = Timestamp
+    public typealias CompareValue = Value
     public var key: SnapshotTimestampKey
     public var value: Timestamp
 }

--- a/FireSnapshot/Sources/Core/QueryBuilder.swift
+++ b/FireSnapshot/Sources/Core/QueryBuilder.swift
@@ -76,6 +76,18 @@ public extension QueryBuilder {
     }
 
     @discardableResult
+    func `where`<V: Equatable>(_ predicate: ArrayContainsAnyPredicate<D, V>) -> Self where V: Equatable {
+        updateQuery(predicate.keyPath, builder: { $0.whereField($1, arrayContainsAny: predicate.value) })
+        return self
+    }
+
+    @discardableResult
+    func `where`<V: Equatable>(_ predicate: InPredicate<D, V>) -> Self where V: Equatable {
+        updateQuery(predicate.keyPath, builder: { $0.whereField($1, in: predicate.value) })
+        return self
+    }
+
+    @discardableResult
     func order(by keyPath: PartialKeyPath<D>, descending: Bool = false) -> Self {
         updateQuery(keyPath, builder: { $0.order(by: $1, descending: descending) })
         return self

--- a/Podfile
+++ b/Podfile
@@ -2,12 +2,12 @@ source 'https://cdn.cocoapods.org/'
 
 target 'FireSnapshot' do
   use_frameworks!
-  pod 'Firebase/Firestore', '~> 6.11'
+  pod 'Firebase/Firestore', '~> 6.12'
   pod 'FirebaseFirestoreSwift', '~> 0.2'
-  pod 'Firebase/Storage', '~> 6.11'
+  pod 'Firebase/Storage', '~> 6.12'
 
   target 'FireSnapshotTests' do
-    pod 'Firebase/Core', '~> 6.11'
+    pod 'Firebase/Core', '~> 6.12'
     inherit! :search_paths
   end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,28 +5,28 @@ PODS:
   - BoringSSL-GRPC/Implementation (0.0.3):
     - BoringSSL-GRPC/Interface (= 0.0.3)
   - BoringSSL-GRPC/Interface (0.0.3)
-  - Firebase/Core (6.11.0):
+  - Firebase/Core (6.12.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 6.1.3)
-  - Firebase/CoreOnly (6.11.0):
-    - FirebaseCore (= 6.3.2)
-  - Firebase/Firestore (6.11.0):
+    - FirebaseAnalytics (= 6.1.5)
+  - Firebase/CoreOnly (6.12.0):
+    - FirebaseCore (= 6.3.3)
+  - Firebase/Firestore (6.12.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 1.6.1)
-  - Firebase/Storage (6.11.0):
+    - FirebaseFirestore (~> 1.7.0)
+  - Firebase/Storage (6.12.0):
     - Firebase/CoreOnly
     - FirebaseStorage (~> 3.4.1)
-  - FirebaseAnalytics (6.1.3):
+  - FirebaseAnalytics (6.1.5):
     - FirebaseCore (~> 6.3)
     - FirebaseInstanceID (~> 4.2)
-    - GoogleAppMeasurement (= 6.1.3)
+    - GoogleAppMeasurement (= 6.1.5)
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
     - GoogleUtilities/MethodSwizzler (~> 6.0)
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
-    - nanopb (~> 0.3.901)
+    - nanopb (= 0.3.9011)
   - FirebaseAuthInterop (1.0.0)
-  - FirebaseCore (6.3.2):
+  - FirebaseCore (6.3.3):
     - FirebaseCoreDiagnostics (~> 1.0)
     - FirebaseCoreDiagnosticsInterop (~> 1.0)
     - GoogleUtilities/Environment (~> 6.2)
@@ -37,16 +37,16 @@ PODS:
     - GoogleUtilities/Environment (~> 6.2)
     - GoogleUtilities/Logger (~> 6.2)
     - nanopb (~> 0.3.901)
-  - FirebaseCoreDiagnosticsInterop (1.0.0)
-  - FirebaseFirestore (1.6.1):
+  - FirebaseCoreDiagnosticsInterop (1.1.0)
+  - FirebaseFirestore (1.7.0):
     - FirebaseAuthInterop (~> 1.0)
     - FirebaseCore (~> 6.2)
-    - FirebaseFirestore/abseil-cpp (= 1.6.1)
+    - FirebaseFirestore/abseil-cpp (= 1.7.0)
     - "gRPC-C++ (= 0.0.9)"
     - leveldb-library (~> 1.22)
     - nanopb (~> 0.3.901)
     - Protobuf (>= 3.9.2, ~> 3.9)
-  - FirebaseFirestore/abseil-cpp (1.6.1):
+  - FirebaseFirestore/abseil-cpp (1.7.0):
     - FirebaseAuthInterop (~> 1.0)
     - FirebaseCore (~> 6.2)
     - "gRPC-C++ (= 0.0.9)"
@@ -55,7 +55,7 @@ PODS:
     - Protobuf (>= 3.9.2, ~> 3.9)
   - FirebaseFirestoreSwift (0.2):
     - FirebaseFirestore (>= 1.6.1, ~> 1.6)
-  - FirebaseInstanceID (4.2.6):
+  - FirebaseInstanceID (4.2.7):
     - FirebaseCore (~> 6.0)
     - GoogleUtilities/Environment (~> 6.0)
     - GoogleUtilities/UserDefaults (~> 6.0)
@@ -63,12 +63,12 @@ PODS:
     - FirebaseAuthInterop (~> 1.0)
     - FirebaseCore (~> 6.0)
     - GTMSessionFetcher/Core (~> 1.1)
-  - GoogleAppMeasurement (6.1.3):
+  - GoogleAppMeasurement (6.1.5):
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
     - GoogleUtilities/MethodSwizzler (~> 6.0)
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
-    - nanopb (~> 0.3.901)
+    - nanopb (= 0.3.9011)
   - GoogleDataTransport (3.0.1)
   - GoogleDataTransportCCTSupport (1.2.1):
     - GoogleDataTransport (~> 3.0)
@@ -117,9 +117,9 @@ PODS:
   - Protobuf (3.10.0)
 
 DEPENDENCIES:
-  - Firebase/Core (~> 6.11)
-  - Firebase/Firestore (~> 6.11)
-  - Firebase/Storage (~> 6.11)
+  - Firebase/Core (~> 6.12)
+  - Firebase/Firestore (~> 6.12)
+  - Firebase/Storage (~> 6.12)
   - FirebaseFirestoreSwift (~> 0.2)
 
 SPEC REPOS:
@@ -148,17 +148,17 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   BoringSSL-GRPC: db8764df3204ccea016e1c8dd15d9a9ad63ff318
-  Firebase: bc9cfc7a96c73268656d5aaab453ff1b4b530e0e
-  FirebaseAnalytics: 0e3ecff2c5d86070f7d4325e21f1edabfbd558dc
+  Firebase: da031bc7012374e3bed17a6731b89327b29863b9
+  FirebaseAnalytics: 4e53a7eb7b76bc703c4d9239bc964545e9b23361
   FirebaseAuthInterop: 0ffa57668be100582bb7643d4fcb7615496c41fc
-  FirebaseCore: beeff42c07c30ea94702471d99db2089b594fbbd
+  FirebaseCore: bcd6c112429249d7921e907d661e8955a3549e26
   FirebaseCoreDiagnostics: af29e43048607588c050889d19204f4d7b758c9f
-  FirebaseCoreDiagnosticsInterop: 6829da2b8d1fc795ff1bd99df751d3788035d2cb
-  FirebaseFirestore: bb8315fa13a15ea8977e940496b74ba6ad9071f2
+  FirebaseCoreDiagnosticsInterop: e9b1b023157e3a2fc6418b5cb601e79b9af7b3a0
+  FirebaseFirestore: 1c7ed32c09d6b0148034e035d0c07783ca45bac3
   FirebaseFirestoreSwift: 0437bb10d83f8161a9131da1739998254c78fdf5
-  FirebaseInstanceID: d0eafcd8bdbd3447cd694594734078c3e3e77d8b
+  FirebaseInstanceID: ebd2ea79ee38db0cb5f5167b17a0d387e1cc7b6e
   FirebaseStorage: b7c6d00997bc21d4465453bdcc5cc65513110fed
-  GoogleAppMeasurement: 434cc7be25e71dc04b8d0e3079125127b330e84a
+  GoogleAppMeasurement: 037f46d1d8ae8b312720f1042585ab961a1289e3
   GoogleDataTransport: 166f9b9f82cbf60a204e8fe2daa9db3e3ec1fb15
   GoogleDataTransportCCTSupport: f6ab1962e9dc05ab1fb938b795e5b310209edeec
   GoogleUtilities: f895fde57977df4e0233edda0dbeac490e3703b6
@@ -169,6 +169,6 @@ SPEC CHECKSUMS:
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   Protobuf: a4dc852ad69c027ca2166ed287b856697814375b
 
-PODFILE CHECKSUM: a5366f43d9574017284729b1611b0c7f47ab9edb
+PODFILE CHECKSUM: d8d174c55416aaec3aa7ee946cd74c55994c72c6
 
-COCOAPODS: 1.8.1
+COCOAPODS: 1.8.4


### PR DESCRIPTION
I have just implemented QueryBuilder's new features to support `array-contains-any` and `in` query.

## Usage

### `array-contains-any`

Use `~||` operator.

```swift
Snapshot.get(.posts, queryBuilderBlock: { 
    $0.where(\.categories ~|| ["food", "tech"])}) { result in
    print(result)
}
```

### `in`

Use `||` operator.

```swift
Snapshot.get(.users, queryBuilderBlock: { 
    $0.where(\.name || ["Mike", "John"])}) { result in
    print(result)
}
```